### PR TITLE
Sprint1/feature/16/weekly calendar in barber view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@mui/x-date-pickers": "^8.3.1",
         "@neondatabase/serverless": "^1.0.0",
         "@prisma/client": "^6.7.0",
+        "@tailwindcss/postcss": "^4.1.8",
         "@types/pg": "^8.11.14",
         "@vercel/analytics": "^1.5.0",
         "date-fns": "^4.1.0",
@@ -34,7 +35,34 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "eslint": "^8.56.0",
-        "eslint-config-next": "14.1.0"
+        "eslint-config-next": "14.1.0",
+        "postcss": "^8.5.4",
+        "tailwindcss": "^4.1.8"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -232,7 +260,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.0.tgz",
       "integrity": "sha512-H+N/FqT07NmLmt6OFFtDfwe8PNygprzBikrEMyQfgqSmT0vzE515Pz7R8izwB9q/zsH/MA64AKoul3sA6/CzVg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.1",
@@ -252,7 +279,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.1.tgz",
       "integrity": "sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1854,7 +1880,6 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.8.tgz",
       "integrity": "sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.4.0",
@@ -2219,6 +2244,329 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.8.tgz",
+      "integrity": "sha512-OWwBsbC9BFAJelmnNcrKuf+bka2ZxCE2A4Ft53Tkg4uoiE67r/PMEYwCsourC26E+kmxfwE0hVzMdxqeW+xu7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "enhanced-resolve": "^5.18.1",
+        "jiti": "^2.4.2",
+        "lightningcss": "1.30.1",
+        "magic-string": "^0.30.17",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.1.8"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.8.tgz",
+      "integrity": "sha512-d7qvv9PsM5N3VNKhwVUhpK6r4h9wtLkJ6lz9ZY9aeZgrUWk1Z8VPyqyDT9MZlem7GTGseRQHkeB1j3tC7W1P+A==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.4",
+        "tar": "^7.4.3"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.1.8",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.8",
+        "@tailwindcss/oxide-darwin-x64": "4.1.8",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.8",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.8",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.8",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.8",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.8",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.8",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.8",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.8",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.8"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.8.tgz",
+      "integrity": "sha512-Fbz7qni62uKYceWYvUjRqhGfZKwhZDQhlrJKGtnZfuNtHFqa8wmr+Wn74CTWERiW2hn3mN5gTpOoxWKk0jRxjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.8.tgz",
+      "integrity": "sha512-RdRvedGsT0vwVVDztvyXhKpsU2ark/BjgG0huo4+2BluxdXo8NDgzl77qh0T1nUxmM11eXwR8jA39ibvSTbi7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.8.tgz",
+      "integrity": "sha512-t6PgxjEMLp5Ovf7uMb2OFmb3kqzVTPPakWpBIFzppk4JE4ix0yEtbtSjPbU8+PZETpaYMtXvss2Sdkx8Vs4XRw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.8.tgz",
+      "integrity": "sha512-g8C8eGEyhHTqwPStSwZNSrOlyx0bhK/V/+zX0Y+n7DoRUzyS8eMbVshVOLJTDDC+Qn9IJnilYbIKzpB9n4aBsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.8.tgz",
+      "integrity": "sha512-Jmzr3FA4S2tHhaC6yCjac3rGf7hG9R6Gf2z9i9JFcuyy0u79HfQsh/thifbYTF2ic82KJovKKkIB6Z9TdNhCXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.8.tgz",
+      "integrity": "sha512-qq7jXtO1+UEtCmCeBBIRDrPFIVI4ilEQ97qgBGdwXAARrUqSn/L9fUrkb1XP/mvVtoVeR2bt/0L77xx53bPZ/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.8.tgz",
+      "integrity": "sha512-O6b8QesPbJCRshsNApsOIpzKt3ztG35gfX9tEf4arD7mwNinsoCKxkj8TgEE0YRjmjtO3r9FlJnT/ENd9EVefQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.8.tgz",
+      "integrity": "sha512-32iEXX/pXwikshNOGnERAFwFSfiltmijMIAbUhnNyjFr3tmWmMJWQKU2vNcFX0DACSXJ3ZWcSkzNbaKTdngH6g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.8.tgz",
+      "integrity": "sha512-s+VSSD+TfZeMEsCaFaHTaY5YNj3Dri8rST09gMvYQKwPphacRG7wbuQ5ZJMIJXN/puxPcg/nU+ucvWguPpvBDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.8.tgz",
+      "integrity": "sha512-CXBPVFkpDjM67sS1psWohZ6g/2/cd+cq56vPxK4JeawelxwK4YECgl9Y9TjkE2qfF+9/s1tHHJqrC4SS6cVvSg==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@emnapi/wasi-threads": "^1.0.2",
+        "@napi-rs/wasm-runtime": "^0.2.10",
+        "@tybys/wasm-util": "^0.9.0",
+        "tslib": "^2.8.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.8.tgz",
+      "integrity": "sha512-7GmYk1n28teDHUjPlIx4Z6Z4hHEgvP5ZW2QS9ygnDAdI/myh3HTHjDqtSqgu1BpRoI4OiLx+fThAyA1JePoENA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.8.tgz",
+      "integrity": "sha512-fou+U20j+Jl0EHwK92spoWISON2OBnCazIc038Xj2TdweYV33ZRkS9nwqiUi2d/Wba5xg5UoHfvynnb/UB49cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tailwindcss/oxide/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.8.tgz",
+      "integrity": "sha512-vB/vlf7rIky+w94aWMw34bWW1ka6g6C3xIOdICKX2GC0VcLtL6fhlLiafF0DVIwa9V6EHz8kbWMkS2s2QvvNlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.1.8",
+        "@tailwindcss/oxide": "4.1.8",
+        "postcss": "^8.4.41",
+        "tailwindcss": "4.1.8"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2262,7 +2610,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -3638,9 +3985,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001717",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001717.tgz",
-      "integrity": "sha512-auPpttCq6BDEG8ZAuHJIplGw6GODhjw+/11e7IjpnYCxZcW/ONgPs0KVBJ0d1bY3e2+7PRe5RCLyP+PfwVgkYw==",
+      "version": "1.0.30001721",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
+      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3654,7 +4001,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4134,6 +4482,19 @@
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
+      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/error-ex": {
@@ -6255,6 +6616,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/jose": {
       "version": "5.9.6",
       "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
@@ -6409,6 +6779,234 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
+      "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-darwin-arm64": "1.30.1",
+        "lightningcss-darwin-x64": "1.30.1",
+        "lightningcss-freebsd-x64": "1.30.1",
+        "lightningcss-linux-arm-gnueabihf": "1.30.1",
+        "lightningcss-linux-arm64-gnu": "1.30.1",
+        "lightningcss-linux-arm64-musl": "1.30.1",
+        "lightningcss-linux-x64-gnu": "1.30.1",
+        "lightningcss-linux-x64-musl": "1.30.1",
+        "lightningcss-win32-arm64-msvc": "1.30.1",
+        "lightningcss-win32-x64-msvc": "1.30.1"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.1.tgz",
+      "integrity": "sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.1.tgz",
+      "integrity": "sha512-k1EvjakfumAQoTfcXUcHQZhSpLlkAuEkdMBsI/ivWw9hL+7FtilQc0Cy3hrx0AAQrVtQAbMI7YjCgYgvn37PzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.1.tgz",
+      "integrity": "sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.1.tgz",
+      "integrity": "sha512-MjxUShl1v8pit+6D/zSPq9S9dQ2NPFSQwGvxBCYaBYLPlCWuPh9/t1MRS8iUaR8i+a6w7aps+B4N0S1TYP/R+Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.1.tgz",
+      "integrity": "sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.1.tgz",
+      "integrity": "sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.1.tgz",
+      "integrity": "sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.1.tgz",
+      "integrity": "sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.1.tgz",
+      "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.1.tgz",
+      "integrity": "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6458,6 +7056,15 @@
       "integrity": "sha512-aKqhOQ+YmFnwq8dWgGjOuLc8V1R9/c/yOd+zDY4+ohsR2Jo05lSGc3WsstYPIzcTpeosN7LoCkLReUUITvaIvw==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-error": {
@@ -7236,6 +7843,34 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postgres-array": {
@@ -8264,6 +8899,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "date-fns": "^4.1.0",
         "dotenv-cli": "^8.0.0",
         "js-cookie": "^3.0.5",
+        "lodash.throttle": "^4.1.1",
         "lucide-react": "^0.487.0",
         "moment": "^2.30.1",
         "next": "^15.3.2",
@@ -7032,6 +7033,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "date-fns": "^4.1.0",
     "dotenv-cli": "^8.0.0",
     "js-cookie": "^3.0.5",
+    "lodash.throttle": "^4.1.1",
     "lucide-react": "^0.487.0",
     "moment": "^2.30.1",
     "next": "^15.3.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/x-date-pickers": "^8.3.1",
     "@neondatabase/serverless": "^1.0.0",
     "@prisma/client": "^6.7.0",
+    "@tailwindcss/postcss": "^4.1.8",
     "@types/pg": "^8.11.14",
     "@vercel/analytics": "^1.5.0",
     "date-fns": "^4.1.0",
@@ -35,6 +36,8 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.1.0"
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^4.1.8"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/src/app/api/appointments/route.js
+++ b/src/app/api/appointments/route.js
@@ -9,16 +9,17 @@ export async function GET(request) {
         const {searchParams} = new URL(request.url);
         const barberId = searchParams.get('barberId');
         const clientPhoneNumber = searchParams.get('clientPhoneNumber');
-        const date = searchParams.get('date');
+        const startDate = searchParams.get('startDate');
+        const endDate = searchParams.get('endDate');
 
         const appointments = await prisma.appointment.findMany({
             where: {
                 ...barberId && {barber_id: barberId},
                 ...clientPhoneNumber && {client_phone_number: clientPhoneNumber},
-                ...date && {
+                ...(startDate || endDate) && {
                     date: {
-                        gte: new Date(date),
-                        lt: new Date(new Date(date).setDate(new Date(date).getDate() + 1))
+                        ...startDate && {gte: new Date(startDate).toISOString()},
+                        ...endDate && {lte: new Date(endDate).toISOString()},
                     }
                 }
             },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,11 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  padding-right: 0 !important;
+}
+
+.MuiAppBar-root{
+  padding-right: 0 !important;
 }
 
 a {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,7 +1,9 @@
+@import "tailwindcss";
+
 * {
   box-sizing: border-box;
-  padding: 0;
-  margin: 0;
+  /*padding: 0;*/
+  /*margin: 0;*/
 }
 
 html,

--- a/src/app/management/appointments/page.js
+++ b/src/app/management/appointments/page.js
@@ -5,7 +5,7 @@ import {useRouter} from "next/navigation";
 import Cookies from "js-cookie";
 import {Appointment} from "@/entities/Appointment";
 import ManagementSection from "@/components/ManagementSection";
-import {format} from "date-fns";
+import {endOfDay, format, startOfDay} from "date-fns";
 import {Service} from '@/entities/Service';
 import {getTranslations} from '@/translations';
 import {Barber} from "@/entities/Barber";
@@ -34,8 +34,9 @@ export default function AppointmentsManagementPage() {
 
     const loadAppointments = useCallback(async () => {
         try {
-            const appointmentsList = await Appointment.getAll({
-                date: selectedDate,
+            const appointmentsList = await Appointment.get({
+                startDate: startOfDay(selectedDate),
+                endDate: endOfDay(selectedDate),
             });
 
             let filteredAppointments = userData.role === "BARBER" ? appointmentsList.filter((a)=>a.barberId === userData.id) : appointmentsList;
@@ -45,7 +46,7 @@ export default function AppointmentsManagementPage() {
         } catch (error) {
             setError("Failed to load appointments");
         }
-    }, [selectedDate]);
+    }, [selectedDate, userData.id, userData.role]);
 
     const loadServices = async () => {
         try {

--- a/src/app/management/page.js
+++ b/src/app/management/page.js
@@ -120,8 +120,8 @@ export default function ManagementDashboard() {
                 selectedBarberId={selectedBarber?.id}
                 onBarberChange={setSelectedBarber}
                 locale={{code: 'he-IL', localize: localizeIL}}
-                initialDate={new Date()}
                 weekStartsOn={0}
+                getWeeklySchedule={(startDayOfWeek) => selectedBarber && Object.values(selectedBarber.workingHours)}
                 disabledCell={(date) => {
                     return isBefore(date, new Date());
                 }}
@@ -132,8 +132,8 @@ export default function ManagementDashboard() {
                     {
                         id: "1",
                         title: "Meeting",
-                        startDate: setMinutes(setHours(new Date(), 15), 15),
-                        endDate: setMinutes(setHours(new Date(), 16), 20),
+                        startDate: setMinutes(setHours(new Date(), 18), 30),
+                        endDate: setMinutes(setHours(new Date(), 19), 30),
                     },
                 ]}
                 onCellClick={(cell) => alert(`Clicked ${format(cell.date, "Pp")}`)}

--- a/src/app/management/page.js
+++ b/src/app/management/page.js
@@ -1,23 +1,44 @@
 'use client';
 
-import {format, isBefore, setHours, setMinutes, startOfWeek} from "date-fns";
-import React, {useEffect, useState} from 'react';
-import {Box, Button, Card, CardActions, CardContent, Grid, Typography} from '@mui/material';
+import {addMinutes, endOfWeek, format, isBefore, startOfWeek} from "date-fns";
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {Box, Typography, useMediaQuery, useTheme} from '@mui/material';
 import {Calendar, Scissors, User} from 'lucide-react';
 import Cookies from 'js-cookie';
 import {getTranslations} from '@/translations';
 import WeekView from '@/components/WeekView/WeekView';
 import localizeIL from '@/lib/he-IL-localize';
 import {Barber} from '@/entities/Barber';
+import {Appointment} from '@/entities/Appointment';
+import ManagementDialog from '@/components/ManagementDialog';
+import {Service} from '@/entities/Service';
+import throttle from 'lodash.throttle';
 
 const t = getTranslations(true);
 
 export default function ManagementDashboard() {
-    const [upcomingAppointments, setUpcomingAppointments] = useState([]);
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+    const [appointments, setAppointments] = useState([]);
+    const [startOfTheWeek, setStartOfTheWeek] = useState(null);
     const [error, setError] = useState(null);
     const [user, setUser] = useState(null);
     const [barbers, setBarbers] = useState(undefined);
+    const [services, setServices] = useState([]);
     const [selectedBarber, setSelectedBarber] = useState(null);
+    const [openDialog, setOpenDialog] = useState(false);
+    const [editingItem, setEditingItem] = useState(null);
+
+    const initialFormData = {
+        clientName: '',
+        clientPhoneNumber: '',
+        date: '',
+        time: "",
+        serviceId: services?.[0]?.id,
+        barberId: barbers?.[0]?.id,
+    };
+
+    const [formData, setFormData] = useState();
 
     useEffect(() => {
         const userData = JSON.parse(Cookies.get('userData') || '{}');
@@ -26,7 +47,7 @@ export default function ManagementDashboard() {
         if (!userData.id || (userData.role !== 'ADMIN' && userData.role !== 'BARBER')) {
             throw new Error('לא נמצא מידע עבור המשתמש המחובר');
         } else {
-            void loadAppointments(userData);
+            void loadServices();
 
             (async function () {
                 if (userData.role === 'ADMIN') {
@@ -40,40 +61,124 @@ export default function ManagementDashboard() {
         }
     }, []);
 
+    const LoadWeeklyAppointments = useCallback(() => {
+        if (selectedBarber && startOfTheWeek) {
+            Appointment.get({
+                barberId: selectedBarber.id,
+                startDate: startOfTheWeek,
+                endDate: endOfWeek(startOfTheWeek),
+            }).then(res => {
+                setAppointments(res);
+                console.log(res);
+            }).catch((error) => {
+                console.error('Error loading appointments:', error);
+                setError(error.message || 'Failed to load appointments');
+            });
+        }
+    }, [selectedBarber, startOfTheWeek]);
+
+    const throttledLoadWeeklyAppointments = useMemo(() => throttle(LoadWeeklyAppointments, 3000, {
+        leading: true,
+        trailing: false
+    }), [LoadWeeklyAppointments]);
+
+    useEffect(() => {
+        LoadWeeklyAppointments();
+        const intervalId = setInterval(LoadWeeklyAppointments, 60000);
+
+        return () => {
+            clearInterval(intervalId);
+        };
+    }, [LoadWeeklyAppointments]);
+
     const loadBarbers = async () => {
         try {
             return await Barber.getAll();
         } catch (error) {
             setError('Failed to load barbers');
         }
+
+    };
+    const loadServices = async () => {
+        try {
+            setServices(await Service.getAll());
+        } catch (error) {
+            setError('Failed to load services');
+        }
+
+    };
+    //
+    // useEffect(() => {
+    //     LoadWeeklyAppointments();
+    // }, [throttledLoadWeeklyAppointments, selectedBarber, startOfTheWeek]);
+
+    const handleStartOfWeekChange = useCallback((startOfWeek) => {
+        setStartOfTheWeek(startOfWeek);
+    }, []);
+
+    const handleOpenDialog = (item = null, date, time) => {
+        if (item) {
+            setEditingItem(item);
+            setFormData(item);
+        } else {
+            setEditingItem(null);
+            setFormData({...initialFormData, date, time});
+        }
+        setOpenDialog(true);
     };
 
-    const loadAppointments = async (userData) => {
+    const handleCloseDialog = () => {
+        setOpenDialog(false);
+        setEditingItem(null);
+        setFormData(initialFormData);
+    };
+
+    const handleFormChange = (e) => {
+        const {name, value} = e.target;
+        setFormData(prev => ({
+            ...prev,
+            [name]: value
+        }));
+    };
+
+    const handleAdd = async (formData) => {
         try {
-            // Get user data from cookie
-
-            // Get today's date in YYYY-MM-DD format
-            const today = new Date().toISOString().split('T')[0];
-
-            // Fetch appointments with barber ID (which is the same as user ID in our schema)
-            const response = await fetch(`/api/appointments?date=${today}${userData.role === 'BARBER' ? `&barberId=${userData.id}` : ''}`);
-
-            if (!response.ok) {
-                const errorData = await response.json();
-                throw new Error(errorData.error || 'Failed to load appointments');
-            }
-
-            const appointments = await response.json();
-
-            // Filter and sort upcoming appointments
-            const upcoming = appointments
-                .filter(app => new Date(app.dateTime) > new Date())
-                .sort((a, b) => new Date(a.dateTime) - new Date(b.dateTime))
-                .slice(0, 5); // Show only next 5 appointments
-            setUpcomingAppointments(upcoming);
+            await new Appointment(formData).save();
+            LoadWeeklyAppointments();
         } catch (error) {
-            console.error('Error loading appointments:', error);
-            setError(error.message || 'Failed to load appointments');
+            setError("Failed to save appointment");
+        }
+    };
+
+    const handleEdit = async (id, formData) => {
+        try {
+            const {barberId, serviceId} = formData;
+
+            console.log(formData);
+
+            await new Appointment({
+                ...formData,
+                barber: barbers.find(b => b.id === barberId),
+                service: services.find(s => s.id === serviceId),
+                id,
+            }).save();
+            LoadWeeklyAppointments();
+        } catch (error) {
+            setError("Failed to update appointment");
+        }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            if (editingItem) {
+                await handleEdit(editingItem.id, formData);
+            } else {
+                await handleAdd(formData);
+            }
+            handleCloseDialog();
+        } catch (error) {
+            console.error('Failed to save item:', error);
         }
     };
 
@@ -103,6 +208,49 @@ export default function ManagementDashboard() {
         );
     }
 
+    const appointmentFields = [
+        {
+            name: "clientName",
+            label: "שם לקוח",
+            required: true,
+        },
+        {
+            name: "clientPhoneNumber",
+            label: "טלפון",
+            required: true,
+        },
+        {
+            name: "date",
+            label: "תאריך",
+            type: "date",
+            required: true,
+        },
+        {
+            name: "time",
+            label: "שעה",
+            type: "time",
+            required: true,
+        },
+        {
+            name: "barberId",
+            label: "ספר",
+            type: "select",
+            required: true,
+            options: barbers?.map((barber) => ({
+                value: barber.id,
+                label: `${barber.firstName} ${barber.lastName}`
+            })), // This should be populated with available services
+        },
+        {
+            name: "serviceId",
+            label: "שירות",
+            type: "select",
+            required: true,
+            options: services?.map((service) => ({value: service.id, label: service.name})), // This should be populated
+            // with available services
+        },
+    ];
+
     return (
         <Box>
             <Typography variant="h4" component="h1" gutterBottom>
@@ -116,7 +264,9 @@ export default function ManagementDashboard() {
             )}
 
             <WeekView
+                onReload={throttledLoadWeeklyAppointments}
                 barbers={barbers}
+                onStartOfWeekChange={handleStartOfWeekChange}
                 selectedBarberId={selectedBarber?.id}
                 onBarberChange={setSelectedBarber}
                 locale={{code: 'he-IL', localize: localizeIL}}
@@ -128,83 +278,98 @@ export default function ManagementDashboard() {
                 disabledWeek={(startDayOfWeek) => {
                     return isBefore(startDayOfWeek, startOfWeek(new Date()));
                 }}
-                events={[
-                    {
-                        id: "1",
-                        title: "Meeting",
-                        startDate: setMinutes(setHours(new Date(), 18), 30),
-                        endDate: setMinutes(setHours(new Date(), 19), 30),
-                    },
-                ]}
-                onCellClick={(cell) => alert(`Clicked ${format(cell.date, "Pp")}`)}
-                onEventClick={(event) =>
-                    alert(
-                        `${event.title} ${format(event.startDate, "Pp")} - ${format(
-                            event.endDate,
-                            "Pp"
-                        )}`
-                    )
+                events={
+                    appointments.map(({id, date, time, service}) => {
+                        const startDate = new Date(`${date.split("T")[0]}T${time}`);
+
+                        return {
+                            id,
+                            title: service.name,
+                            startDate,
+                            endDate: addMinutes(startDate, service.duration_minutes),
+                        };
+                    })
+                }
+                onCellClick={(cell) => {
+                    handleOpenDialog(null, format(cell.date, 'yyyy-MM-dd'), cell.hourAndMinute);
+                    console.log(cell.date);
+                }}
+                onEventClick={(event) => {
+                    handleOpenDialog(appointments.find(({id}) => event.id === id));
+                }
                 }
             />
 
-            <Grid container spacing={3}>
-                {/* Management Cards */}
-                <Grid item xs={12}>
-                    <Grid container spacing={3}>
-                        {managementCards.reverse().map((card) => (
-                            <Grid item xs={12} sm={6} md={3} key={card.title}>
-                                <Card
-                                    sx={{
-                                        height: '100%',
-                                        display: 'flex',
-                                        flexDirection: 'column',
-                                        background: `linear-gradient(145deg, ${card.color}20, ${card.color}10)`,
-                                        border: `1px solid ${card.color}30`,
-                                        minWidth: '280px',
-                                        width: '100%'
-                                    }}>
-                                    <CardContent sx={{flexGrow: 1}}>
-                                        <Box sx={{display: 'flex', alignItems: 'center', mb: 2}}>
-                                            <Box sx={{
-                                                p: 1,
-                                                borderRadius: '50%',
-                                                bgcolor: `${card.color}20`,
-                                                mr: 2,
-                                                marginLeft: 2
-                                            }}>
-                                                {card.icon}
-                                            </Box>
-                                            <Typography variant="h6" component="h2">
-                                                {card.title}
-                                            </Typography>
-                                        </Box>
-                                        <Typography color="text.secondary">
-                                            {card.description}
-                                        </Typography>
-                                    </CardContent>
-                                    <div style={{display: 'flex', width: '100%', justifyContent: 'center'}}>
-                                        <CardActions>
-                                            <Button
-                                                size="small"
-                                                href={card.href}
-                                                sx={{
-                                                    color: card.color,
-                                                    '&:hover': {
-                                                        bgcolor: `${card.color}10`
-                                                    }
-                                                }}>
-                                                בחר
-                                            </Button>
-                                        </CardActions>
-                                    </div>
-                                </Card>
-                            </Grid>
-                        ))}
-                    </Grid>
-                </Grid>
+            {/*<Grid container spacing={3}>*/}
+            {/*    /!* Management Cards *!/*/}
+            {/*    <Grid item xs={12}>*/}
+            {/*        <Grid container spacing={3}>*/}
+            {/*            {managementCards.reverse().map((card) => (*/}
+            {/*                <Grid item xs={12} sm={6} md={3} key={card.title}>*/}
+            {/*                    <Card*/}
+            {/*                        sx={{*/}
+            {/*                            height: '100%',*/}
+            {/*                            display: 'flex',*/}
+            {/*                            flexDirection: 'column',*/}
+            {/*                            background: `linear-gradient(145deg, ${card.color}20, ${card.color}10)`,*/}
+            {/*                            border: `1px solid ${card.color}30`,*/}
+            {/*                            minWidth: '280px',*/}
+            {/*                            width: '100%'*/}
+            {/*                        }}>*/}
+            {/*                        <CardContent sx={{flexGrow: 1}}>*/}
+            {/*                            <Box sx={{display: 'flex', alignItems: 'center', mb: 2}}>*/}
+            {/*                                <Box sx={{*/}
+            {/*                                    p: 1,*/}
+            {/*                                    borderRadius: '50%',*/}
+            {/*                                    bgcolor: `${card.color}20`,*/}
+            {/*                                    mr: 2,*/}
+            {/*                                    marginLeft: 2*/}
+            {/*                                }}>*/}
+            {/*                                    {card.icon}*/}
+            {/*                                </Box>*/}
+            {/*                                <Typography variant="h6" component="h2">*/}
+            {/*                                    {card.title}*/}
+            {/*                                </Typography>*/}
+            {/*                            </Box>*/}
+            {/*                            <Typography color="text.secondary">*/}
+            {/*                                {card.description}*/}
+            {/*                            </Typography>*/}
+            {/*                        </CardContent>*/}
+            {/*                        <div style={{display: 'flex', width: '100%', justifyContent: 'center'}}>*/}
+            {/*                            <CardActions>*/}
+            {/*                                <Button*/}
+            {/*                                    size="small"*/}
+            {/*                                    href={card.href}*/}
+            {/*                                    sx={{*/}
+            {/*                                        color: card.color,*/}
+            {/*                                        '&:hover': {*/}
+            {/*                                            bgcolor: `${card.color}10`*/}
+            {/*                                        }*/}
+            {/*                                    }}>*/}
+            {/*                                    בחר*/}
+            {/*                                </Button>*/}
+            {/*                            </CardActions>*/}
+            {/*                        </div>*/}
+            {/*                    </Card>*/}
+            {/*                </Grid>*/}
+            {/*            ))}*/}
+            {/*        </Grid>*/}
+            {/*    </Grid>*/}
+            {/*</Grid>*/}
 
-
-            </Grid>
+            {
+                formData && appointmentFields &&
+                <ManagementDialog
+                    open={openDialog}
+                    onClose={handleCloseDialog}
+                    title={`${editingItem ? "ערוך" : "הוסף"} תור`}
+                    formData={formData}
+                    onFormChange={handleFormChange}
+                    onSubmit={handleSubmit}
+                    fields={appointmentFields}
+                    isMobile={isMobile}
+                />
+            }
         </Box>
     );
-} 
+}

--- a/src/app/management/page.js
+++ b/src/app/management/page.js
@@ -1,10 +1,12 @@
 'use client';
 
-import {useEffect, useState} from 'react';
-import {Box, Button, Card, CardActions, CardContent, Chip, Divider, Grid, Paper, Typography} from '@mui/material';
-import {Calendar, Clock, Scissors, User} from 'lucide-react';
+import {format, isBefore, setHours, setMinutes, startOfWeek} from "date-fns";
+import React, {useEffect, useState} from 'react';
+import {Box, Button, Card, CardActions, CardContent, Grid, Typography} from '@mui/material';
+import {Calendar, Scissors, User} from 'lucide-react';
 import Cookies from 'js-cookie';
 import {getTranslations} from '@/translations';
+import WeekView from '@/components/WeekView/WeekView';
 
 const t = getTranslations(true);
 
@@ -90,62 +92,33 @@ export default function ManagementDashboard() {
                 </Typography>
             )}
 
-
-            {/* Next Appointment */}
-            {upcomingAppointments.length === 0 ? (
-                <Paper sx={{p: 3, mb: 3}}>
-                    <Typography variant="h5" gutterBottom>אין תורים קרובים להיום</Typography>
-                </Paper>
-            ) : (
-                <Paper sx={{p: 3, mb: 3}}>
-                    <Typography variant="h5" gutterBottom>
-                        התור הבא
-                    </Typography>
-                    <Divider sx={{mb: 2}}/>
-                    <Card
-                        sx={{
-                            minWidth: '280px',
-                            width: '100%'
-                        }}
-                    >
-                        <CardContent>
-                            <Box sx={{display: 'flex', justifyContent: 'space-between', mb: 1}}>
-                                <Typography variant="subtitle1">
-                                    {upcomingAppointments[0].customerName}
-                                </Typography>
-                                <Chip
-                                    label={upcomingAppointments[0].status}
-                                    size="small"
-                                    color={upcomingAppointments[0].status === 'confirmed' ? 'success' : 'warning'}
-                                />
-                            </Box>
-                            <Box sx={{display: 'flex', alignItems: 'center', mb: 1}}>
-                                <Clock size={16} style={{marginRight: 8}}/>
-                                <Typography variant="body2">
-                                    {new Date(upcomingAppointments[0].dateTime).toLocaleString()}
-                                </Typography>
-                            </Box>
-                            <Box sx={{display: 'flex', alignItems: 'center', mb: 1}}>
-                                <Scissors size={16} style={{marginRight: 8}}/>
-                                <Typography variant="body2">
-                                    {upcomingAppointments[0].serviceName}
-                                </Typography>
-                            </Box>
-                            <Box sx={{display: 'flex', alignItems: 'center'}}>
-                                <User size={16} style={{marginRight: 8}}/>
-                                <Typography variant="body2">
-                                    {upcomingAppointments[0].barberName}
-                                </Typography>
-                            </Box>
-                        </CardContent>
-                        <CardActions>
-                            <Button size="small" href={`/management/appointments/${upcomingAppointments[0].id}`}>
-                                View Details
-                            </Button>
-                        </CardActions>
-                    </Card>
-                </Paper>
-            )}
+            <WeekView
+                initialDate={new Date()}
+                weekStartsOn={0}
+                disabledCell={(date) => {
+                    return isBefore(date, new Date());
+                }}
+                disabledWeek={(startDayOfWeek) => {
+                    return isBefore(startDayOfWeek, startOfWeek(new Date()));
+                }}
+                events={[
+                    {
+                        id: "1",
+                        title: "Meeting",
+                        startDate: setMinutes(setHours(new Date(), 15), 15),
+                        endDate: setMinutes(setHours(new Date(), 16), 20),
+                    },
+                ]}
+                onCellClick={(cell) => alert(`Clicked ${format(cell.date, "Pp")}`)}
+                onEventClick={(event) =>
+                    alert(
+                        `${event.title} ${format(event.startDate, "Pp")} - ${format(
+                            event.endDate,
+                            "Pp"
+                        )}`
+                    )
+                }
+            />
 
             <Grid container spacing={3}>
                 {/* Management Cards */}

--- a/src/components/ManagementDialog.js
+++ b/src/components/ManagementDialog.js
@@ -43,7 +43,7 @@ export default function ManagementDialog({
                     }}
                     size={isMobile ? "medium" : "small"}
                   >
-                    {field.options.map((option) => (
+                    {field.options?.map((option) => (
                       <option key={option.value} value={option.value}>
                         {option.label}
                       </option>

--- a/src/components/WeekView/DaysHeader.tsx
+++ b/src/components/WeekView/DaysHeader.tsx
@@ -4,7 +4,7 @@ import {Days} from './use-weekview';
 export default function DaysHeader({days}: { days: Days }) {
     return (
         <div className="sticky top-0 z-30 flex-none bg-white shadow">
-            <div className={`grid ${"grid-cols-" + days.length} text-sm leading-6 text-slate-500`}>
+            <div className={`grid grid-cols text-sm leading-6 text-slate-500`} style={{gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`}}>
                 {days.map((day, index) => (
                     <div key={getUnixTime(day.date)}
                          className={`

--- a/src/components/WeekView/DaysHeader.tsx
+++ b/src/components/WeekView/DaysHeader.tsx
@@ -1,35 +1,33 @@
-import { getUnixTime } from "date-fns";
+import {getUnixTime} from "date-fns";
 import {Days} from './use-weekview';
 
-export default function DaysHeader({ days }: { days: Days }) {
-  return (
-    <div className="sticky top-0 z-30 flex-none bg-white shadow">
-      <div className="grid grid-cols-7 text-sm leading-6 text-slate-500">
-        {days.map((day, index) => (
-          <div
-            key={getUnixTime(day.date)}
-            className={`
-              flex items-center justify-center h-14 border-l border-gray-100
+export default function DaysHeader({days}: { days: Days }) {
+    return (
+        <div className="sticky top-0 z-30 flex-none bg-white shadow">
+            <div className={`grid ${"grid-cols-" + days.length} text-sm leading-6 text-slate-500`}>
+                {days.map((day, index) => (
+                    <div key={getUnixTime(day.date)}
+                         className={`
+              flex items-center justify-center h-14 border-r border-gray-100
               ${index === 0 && "border-l-0"}
-            `}
-          >
+            `}>
             <span className={day.isToday ? "flex items-center" : ""}>
-              {day.shortName}{" "}
-              <span
-                className={`
-                  font-semibold text-slate-900
+                <span
+                    className={`
+                  font-semibold text-slate-900 ml-1.5
                   ${
-                    day.isToday &&
-                    "flex items-center justify-center rounded-full w-8 h-8 ml-1.5 text-white bg-[#3c795b]"
-                  }
+                        day.isToday &&
+                        "flex items-center justify-center rounded-full w-8 h-8 ml-1.5 text-white bg-[#3c795b]"
+                    }
                 `}
-              >
+                >
                 {day.dayOfMonthWithZero}
               </span>
+                {day.shortName}{" "}
             </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
 }

--- a/src/components/WeekView/DaysHeader.tsx
+++ b/src/components/WeekView/DaysHeader.tsx
@@ -1,7 +1,11 @@
 import {getUnixTime} from "date-fns";
 import {Days} from './use-weekview';
+import {useMediaQuery, useTheme} from '@mui/material';
 
 export default function DaysHeader({days}: { days: Days }) {
+    const theme = useTheme();
+    const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
     return (
         <div className="sticky top-0 z-30 flex-none bg-white shadow">
             <div className={`grid grid-cols text-sm leading-6 text-slate-500`} style={{gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`}}>
@@ -23,7 +27,7 @@ export default function DaysHeader({days}: { days: Days }) {
                 >
                 {day.dayOfMonthWithZero}
               </span>
-                {day.shortName}{" "}
+                {isMobile ? day.shortName.split(' ')[1] : day.shortName}
             </span>
                     </div>
                 ))}

--- a/src/components/WeekView/DaysHeader.tsx
+++ b/src/components/WeekView/DaysHeader.tsx
@@ -1,0 +1,35 @@
+import { getUnixTime } from "date-fns";
+import {Days} from './use-weekview';
+
+export default function DaysHeader({ days }: { days: Days }) {
+  return (
+    <div className="sticky top-0 z-30 flex-none bg-white shadow">
+      <div className="grid grid-cols-7 text-sm leading-6 text-slate-500">
+        {days.map((day, index) => (
+          <div
+            key={getUnixTime(day.date)}
+            className={`
+              flex items-center justify-center h-14 border-l border-gray-100
+              ${index === 0 && "border-l-0"}
+            `}
+          >
+            <span className={day.isToday ? "flex items-center" : ""}>
+              {day.shortName}{" "}
+              <span
+                className={`
+                  font-semibold text-slate-900
+                  ${
+                    day.isToday &&
+                    "flex items-center justify-center rounded-full w-8 h-8 ml-1.5 text-white bg-[#3c795b]"
+                  }
+                `}
+              >
+                {day.dayOfMonthWithZero}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeekView/EventGrid.tsx
+++ b/src/components/WeekView/EventGrid.tsx
@@ -1,96 +1,93 @@
 import {
-  Locale,
-  format,
-  getDay,
-  getHours,
-  getMinutes,
-  isSameWeek, Day,
+    Locale,
+    format,
+    getDay,
+    getHours,
+    getMinutes,
+    isSameWeek, Day,
 } from "date-fns";
 import {Days} from './use-weekview';
 import {Event} from './WeekView';
 
 export default function EventGrid({
-  days,
-  events,
-  weekStartsOn,
-  locale,
-  minuteStep,
-  rowHeight,
-  onEventClick,
-}: {
-  days: Days;
-  events?: Event[];
-  weekStartsOn: Day;
-  locale?: Locale;
-  minuteStep: number;
-  rowHeight: number;
-  onEventClick?: (event: Event) => void;
+                                      days,
+                                      events,
+                                      weekStartsOn,
+                                      locale,
+                                      minuteStep,
+                                      rowHeight,
+                                      onEventClick,
+                                  }: {
+    days: Days;
+    events?: Event[];
+    weekStartsOn: Day;
+    locale?: Locale;
+    minuteStep: number;
+    rowHeight: number;
+    onEventClick?: (event: Event) => void;
 }) {
-  return (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
-        gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
-      }}
-    >
-      {(events || [])
-        .filter((event) => isSameWeek(days[0].date, event.startDate))
-        .map((event) => {
-          const start =
-            getHours(event.startDate) * 2 +
-            1 +
-            Math.floor(getMinutes(event.startDate) / minuteStep);
-          const end =
-            getHours(event.endDate) * 2 +
-            1 +
-            Math.ceil(getMinutes(event.endDate) / minuteStep);
+    return (
+        <div style={{
+            display: "grid",
+            gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
+            gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
+        }}>
+            {(events || [])
+                .filter((event) => isSameWeek(days[0].date, event.startDate))
+                .map((event) => {
+                    const start =
+                        getHours(event.startDate) * 2 +
+                        1 +
+                        Math.floor(getMinutes(event.startDate) / minuteStep);
+                    const end =
+                        getHours(event.endDate) * 2 +
+                        1 +
+                        Math.ceil(getMinutes(event.endDate) / minuteStep);
 
-          const paddingTop =
-            ((getMinutes(event.startDate) % minuteStep) / minuteStep) *
-            rowHeight;
+                    const paddingTop =
+                        ((getMinutes(event.startDate) % minuteStep) / minuteStep) *
+                        rowHeight;
 
-          const paddingBottom =
-            (rowHeight -
-              ((getMinutes(event.endDate) % minuteStep) / minuteStep) *
-                rowHeight) %
-            rowHeight;
+                    const paddingBottom =
+                        (rowHeight -
+                            ((getMinutes(event.endDate) % minuteStep) / minuteStep) *
+                            rowHeight) %
+                        rowHeight;
 
-          return (
-            <div
-              key={event.id}
-              className="relative flex mt-[1px] transition-all"
-              style={{
-                gridRowStart: start,
-                gridRowEnd: end,
-                gridColumnStart: getDay(event.startDate) - weekStartsOn + 1,
-                gridColumnEnd: "span 1",
-              }}
-            >
+                    return (
+                        <div key={event.id}
+                             className="relative flex mt-[1px] transition-all"
+                             style={{
+                                 gridRowStart: start,
+                                 gridRowEnd: end,
+                                 gridColumnStart: getDay(event.startDate) - weekStartsOn + 1,
+                                 gridColumnEnd: "span 1",
+                             }}
+                        >
               <span
-                className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
-                style={{
-                  top: paddingTop + 4,
-                  bottom: paddingBottom + 4,
-                }}
-                onClick={() => onEventClick?.(event)}
+                  className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
+                  style={{
+                      top: paddingTop + 4,
+                      bottom: paddingBottom + 4,
+                  }}
+                  onClick={() => onEventClick?.(event)}
               >
                 <p className="text-white leading-4">
                   {format(new Date(event.startDate), "H:mm", {
-                    weekStartsOn,
-                    locale,
+                      weekStartsOn,
+                      locale,
                   })}
-                  -
-                  {format(new Date(event.endDate), "H:mm", {
-                    weekStartsOn,
-                    locale,
-                  })}
+                    -
+                    {format(new Date(event.endDate), "H:mm", {
+                        weekStartsOn,
+                        locale,
+                    })}
                 </p>
                 <p className="font-semibold text-white">{event.title}</p>
               </span>
-            </div>
-          );
-        })}
-    </div>
-  );
+                        </div>
+                    );
+                })}
+        </div>
+    );
 }

--- a/src/components/WeekView/EventGrid.tsx
+++ b/src/components/WeekView/EventGrid.tsx
@@ -1,0 +1,96 @@
+import {
+  Locale,
+  format,
+  getDay,
+  getHours,
+  getMinutes,
+  isSameWeek, Day,
+} from "date-fns";
+import {Days} from './use-weekview';
+import {Event} from './WeekView';
+
+export default function EventGrid({
+  days,
+  events,
+  weekStartsOn,
+  locale,
+  minuteStep,
+  rowHeight,
+  onEventClick,
+}: {
+  days: Days;
+  events?: Event[];
+  weekStartsOn: Day;
+  locale?: Locale;
+  minuteStep: number;
+  rowHeight: number;
+  onEventClick?: (event: Event) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
+        gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
+      }}
+    >
+      {(events || [])
+        .filter((event) => isSameWeek(days[0].date, event.startDate))
+        .map((event) => {
+          const start =
+            getHours(event.startDate) * 2 +
+            1 +
+            Math.floor(getMinutes(event.startDate) / minuteStep);
+          const end =
+            getHours(event.endDate) * 2 +
+            1 +
+            Math.ceil(getMinutes(event.endDate) / minuteStep);
+
+          const paddingTop =
+            ((getMinutes(event.startDate) % minuteStep) / minuteStep) *
+            rowHeight;
+
+          const paddingBottom =
+            (rowHeight -
+              ((getMinutes(event.endDate) % minuteStep) / minuteStep) *
+                rowHeight) %
+            rowHeight;
+
+          return (
+            <div
+              key={event.id}
+              className="relative flex mt-[1px] transition-all"
+              style={{
+                gridRowStart: start,
+                gridRowEnd: end,
+                gridColumnStart: getDay(event.startDate) - weekStartsOn + 1,
+                gridColumnEnd: "span 1",
+              }}
+            >
+              <span
+                className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
+                style={{
+                  top: paddingTop + 4,
+                  bottom: paddingBottom + 4,
+                }}
+                onClick={() => onEventClick?.(event)}
+              >
+                <p className="text-white leading-4">
+                  {format(new Date(event.startDate), "H:mm", {
+                    weekStartsOn,
+                    locale,
+                  })}
+                  -
+                  {format(new Date(event.endDate), "H:mm", {
+                    weekStartsOn,
+                    locale,
+                  })}
+                </p>
+                <p className="font-semibold text-white">{event.title}</p>
+              </span>
+            </div>
+          );
+        })}
+    </div>
+  );
+}

--- a/src/components/WeekView/EventGrid.tsx
+++ b/src/components/WeekView/EventGrid.tsx
@@ -1,11 +1,4 @@
-import {
-    Locale,
-    format,
-    getDay,
-    getHours,
-    getMinutes,
-    isSameWeek, Day,
-} from "date-fns";
+import {Day, getDay, getHours, getMinutes, isSameWeek, Locale,} from "date-fns";
 import {Days} from './use-weekview';
 import {Event} from './WeekView';
 
@@ -13,7 +6,6 @@ export default function EventGrid({
                                       days,
                                       events,
                                       weekStartsOn,
-                                      locale,
                                       minuteStep,
                                       rowHeight,
                                       onEventClick,
@@ -52,9 +44,13 @@ export default function EventGrid({
                             rowHeight) %
                         rowHeight;
 
+                    const eventHeight = rowHeight - (paddingTop + paddingBottom);
+                    // console.log(rowHeight);
+                    // console.log(eventHeight);
+
                     return (
                         <div key={event.id}
-                             className="relative flex mt-[1px] transition-all"
+                             className="relative flex transition-all"
                              style={{
                                  gridRowStart: start,
                                  gridRowEnd: end,
@@ -63,24 +59,27 @@ export default function EventGrid({
                              }}
                         >
                               <span
-                                  className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
+                                  className={`absolute inset-0 flex flex-col justify-center items-center rounded-md text-sm leading-none border border-transparent border-dashed bg-[#B87333] hover:bg-[#c8894c] transition cursor-pointer`}
                                   style={{
-                                      top: paddingTop + 4,
-                                      bottom: paddingBottom + 4,
+                                      height: eventHeight,
                                   }}
                                   onClick={() => onEventClick?.(event)}>
-                                    <p className="text-white leading-4">
-                                      {format(new Date(event.startDate), "H:mm", {
-                                          weekStartsOn,
-                                          locale,
-                                      })}
-                                        -
-                                        {format(new Date(event.endDate), "H:mm", {
-                                            weekStartsOn,
-                                            locale,
-                                        })}
-                                    </p>
-                                    <p className="font-semibold text-white">{event.title}</p>
+                                    {/*{*/}
+                                    {/*    eventLength >= minuteStep && (*/}
+                                    {/*        <p className="text-white leading-4 text-sm">*/}
+                                    {/*            {format(new Date(event.startDate), "H:mm", {*/}
+                                    {/*                weekStartsOn,*/}
+                                    {/*                locale,*/}
+                                    {/*            })}*/}
+                                    {/*            -*/}
+                                    {/*            {format(new Date(event.endDate), "H:mm", {*/}
+                                    {/*                weekStartsOn,*/}
+                                    {/*                locale,*/}
+                                    {/*            })}*/}
+                                    {/*        </p>*/}
+                                    {/*    )*/}
+                                    {/*}*/}
+                                  <p className={`font-semibold w-[100%] text-white line text-center line-clamp-${Math.floor(eventHeight/rowHeight * 3)} overflow-ellipsis`}>{event.title}</p>
                               </span>
                         </div>
                     );

--- a/src/components/WeekView/EventGrid.tsx
+++ b/src/components/WeekView/EventGrid.tsx
@@ -36,12 +36,10 @@ export default function EventGrid({
                 .filter((event) => isSameWeek(days[0].date, event.startDate))
                 .map((event) => {
                     const start =
-                        getHours(event.startDate) * 2 +
-                        1 +
+                        (getHours(event.startDate) - Number(days[0].cells[0].hour)) * 2 +
                         Math.floor(getMinutes(event.startDate) / minuteStep);
                     const end =
-                        getHours(event.endDate) * 2 +
-                        1 +
+                        (getHours(event.endDate) - Number(days[0].cells[0].hour)) * 2 +
                         Math.ceil(getMinutes(event.endDate) / minuteStep);
 
                     const paddingTop =
@@ -64,27 +62,26 @@ export default function EventGrid({
                                  gridColumnEnd: "span 1",
                              }}
                         >
-              <span
-                  className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
-                  style={{
-                      top: paddingTop + 4,
-                      bottom: paddingBottom + 4,
-                  }}
-                  onClick={() => onEventClick?.(event)}
-              >
-                <p className="text-white leading-4">
-                  {format(new Date(event.startDate), "H:mm", {
-                      weekStartsOn,
-                      locale,
-                  })}
-                    -
-                    {format(new Date(event.endDate), "H:mm", {
-                        weekStartsOn,
-                        locale,
-                    })}
-                </p>
-                <p className="font-semibold text-white">{event.title}</p>
-              </span>
+                              <span
+                                  className="absolute inset-1 flex flex-col overflow-y-auto rounded-md p-2 text-xs leading-5 bg-[#B87333] border border-transparent border-dashed hover:bg-[#c8894c] transition cursor-pointer"
+                                  style={{
+                                      top: paddingTop + 4,
+                                      bottom: paddingBottom + 4,
+                                  }}
+                                  onClick={() => onEventClick?.(event)}>
+                                    <p className="text-white leading-4">
+                                      {format(new Date(event.startDate), "H:mm", {
+                                          weekStartsOn,
+                                          locale,
+                                      })}
+                                        -
+                                        {format(new Date(event.endDate), "H:mm", {
+                                            weekStartsOn,
+                                            locale,
+                                        })}
+                                    </p>
+                                    <p className="font-semibold text-white">{event.title}</p>
+                              </span>
                         </div>
                     );
                 })}

--- a/src/components/WeekView/Grid.tsx
+++ b/src/components/WeekView/Grid.tsx
@@ -1,5 +1,5 @@
 import {ReactNode} from "react";
-import {getMinutes, getUnixTime} from "date-fns";
+import {getUnixTime} from "date-fns";
 import {Cell, Days} from './use-weekview';
 
 export default function Grid({
@@ -25,7 +25,7 @@ export default function Grid({
                 day.cells.map((cell, cellIndex) => (
                     <button
                         key={getUnixTime(cell.date)}
-                        className="relative border-t border-l border-gray-100 transition-colors cursor-pointer hover:bg-slate-100 disabled:bg-slate-100"
+                        className="relative border-t border-l border-gray-200 transition-colors cursor-pointer hover:bg-slate-200 disabled:bg-slate-100"
                         style={{
                             gridRowStart: cellIndex + 1,
                             gridRowEnd: cellIndex + 2,
@@ -38,30 +38,27 @@ export default function Grid({
                     </button>
                 ))
             )}
-            <div
-                className="sticky left-0 grid pointer-events-none"
-                style={{
-                    display: "grid",
-                    gridRowStart: 1,
-                    gridRowEnd: -1,
-                    gridColumnStart: 1,
-                    gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
-                }}
-            >
+            <div className="sticky left-0 grid pointer-events-none"
+                 style={{
+                     display: "grid",
+                     gridRowStart: 1,
+                     gridRowEnd: -1,
+                     gridColumnStart: 1,
+                     gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
+                 }}>
                 {days[0].cells.map(
                     (cell, cellIndex) =>
-                        getMinutes(cell.date) === 0 && (
-                            <div
-                                key={getUnixTime(cell.date)}
-                                className="relative flex items-center justify-center border-t border-gray-100"
-                                style={{
-                                    gridRowStart: cellIndex + 1,
-                                    gridRowEnd: cellIndex + 2,
-                                }}
-                            >
-                <span className="absolute top-0 right-0 text-xs text-slate-400 px-1">
-                  {cell.hourAndMinute}
-                </span>
+                        // getMinutes(cell.date) === 0 &&
+                        (
+                            <div key={getUnixTime(cell.date)}
+                                 className="relative flex items-center justify-center border-t border-gray-200"
+                                 style={{
+                                     gridRowStart: cellIndex + 1,
+                                     gridRowEnd: cellIndex + 2,
+                                 }}>
+                                <span className="absolute top-0 right-0 text-xs text-slate-400 px-1">
+                                    {cell.hourAndMinute}
+                                </span>
                             </div>
                         )
                 )}

--- a/src/components/WeekView/Grid.tsx
+++ b/src/components/WeekView/Grid.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from "react";
-import { getMinutes, getUnixTime } from "date-fns";
+import {ReactNode} from "react";
+import {getMinutes, getUnixTime} from "date-fns";
 import {Cell, Days} from './use-weekview';
 
 export default function Grid({
@@ -25,7 +25,7 @@ export default function Grid({
                 day.cells.map((cell, cellIndex) => (
                     <button
                         key={getUnixTime(cell.date)}
-                        className="relative border-t border-l border-gray-100 transition-colors cursor-pointer hover:bg-slate-100 disabled:bg-slate-50"
+                        className="relative border-t border-l border-gray-100 transition-colors cursor-pointer hover:bg-slate-100 disabled:bg-slate-100"
                         style={{
                             gridRowStart: cellIndex + 1,
                             gridRowEnd: cellIndex + 2,
@@ -33,8 +33,7 @@ export default function Grid({
                             gridColumnEnd: dayIndex + 2,
                         }}
                         disabled={cell.disabled}
-                        onClick={() => onCellClick?.(cell)}
-                    >
+                        onClick={() => onCellClick?.(cell)}>
                         {CellContent && CellContent(cell)}
                     </button>
                 ))
@@ -60,7 +59,7 @@ export default function Grid({
                                     gridRowEnd: cellIndex + 2,
                                 }}
                             >
-                <span className="absolute top-0 left-0 text-xs text-slate-400 px-1">
+                <span className="absolute top-0 right-0 text-xs text-slate-400 px-1">
                   {cell.hourAndMinute}
                 </span>
                             </div>

--- a/src/components/WeekView/Grid.tsx
+++ b/src/components/WeekView/Grid.tsx
@@ -1,0 +1,72 @@
+import { ReactNode } from "react";
+import { getMinutes, getUnixTime } from "date-fns";
+import {Cell, Days} from './use-weekview';
+
+export default function Grid({
+                                 days,
+                                 rowHeight,
+                                 CellContent,
+                                 onCellClick,
+                             }: {
+    days: Days;
+    rowHeight: number;
+    onCellClick?: (cell: Cell) => void;
+    CellContent?: (cell: Cell) => ReactNode;
+}) {
+    return (
+        <div
+            style={{
+                display: "grid",
+                gridTemplateColumns: `repeat(${days.length}, minmax(0, 1fr))`,
+                gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
+            }}
+        >
+            {days.map((day, dayIndex) =>
+                day.cells.map((cell, cellIndex) => (
+                    <button
+                        key={getUnixTime(cell.date)}
+                        className="relative border-t border-l border-gray-100 transition-colors cursor-pointer hover:bg-slate-100 disabled:bg-slate-50"
+                        style={{
+                            gridRowStart: cellIndex + 1,
+                            gridRowEnd: cellIndex + 2,
+                            gridColumnStart: dayIndex + 1,
+                            gridColumnEnd: dayIndex + 2,
+                        }}
+                        disabled={cell.disabled}
+                        onClick={() => onCellClick?.(cell)}
+                    >
+                        {CellContent && CellContent(cell)}
+                    </button>
+                ))
+            )}
+            <div
+                className="sticky left-0 grid pointer-events-none"
+                style={{
+                    display: "grid",
+                    gridRowStart: 1,
+                    gridRowEnd: -1,
+                    gridColumnStart: 1,
+                    gridTemplateRows: `repeat(${days[0].cells.length}, minmax(${rowHeight}px, 1fr))`,
+                }}
+            >
+                {days[0].cells.map(
+                    (cell, cellIndex) =>
+                        getMinutes(cell.date) === 0 && (
+                            <div
+                                key={getUnixTime(cell.date)}
+                                className="relative flex items-center justify-center border-t border-gray-100"
+                                style={{
+                                    gridRowStart: cellIndex + 1,
+                                    gridRowEnd: cellIndex + 2,
+                                }}
+                            >
+                <span className="absolute top-0 left-0 text-xs text-slate-400 px-1">
+                  {cell.hourAndMinute}
+                </span>
+                            </div>
+                        )
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/WeekView/Grid.tsx
+++ b/src/components/WeekView/Grid.tsx
@@ -56,7 +56,7 @@ export default function Grid({
                                      gridRowStart: cellIndex + 1,
                                      gridRowEnd: cellIndex + 2,
                                  }}>
-                                <span className="absolute top-0 right-0 text-xs text-slate-400 px-1">
+                                <span className="absolute z-1000 top-0 right-0 text-xs text-slate-400 px-1">
                                     {cell.hourAndMinute}
                                 </span>
                             </div>

--- a/src/components/WeekView/Header.tsx
+++ b/src/components/WeekView/Header.tsx
@@ -1,0 +1,96 @@
+import { ReactNode } from "react";
+
+export default function Header({
+  title,
+  showTodayButton = true,
+  todayButton,
+  onToday,
+  showPrevButton = true,
+  prevButton,
+  onPrev,
+  showNextButton = true,
+  nextButton,
+  onNext,
+}: {
+  title: ReactNode;
+  showTodayButton?: boolean;
+  todayButton?: ({ onToday }: { onToday?: () => void }) => ReactNode;
+  onToday?: () => void;
+  showPrevButton?: boolean;
+  prevButton?: ({ onPrev }: { onPrev?: () => void }) => ReactNode;
+  onPrev?: () => void;
+  showNextButton?: boolean;
+  nextButton?: ({ onNext }: { onNext?: () => void }) => ReactNode;
+  onNext?: () => void;
+}) {
+  return (
+    <header className="flex items-center justify-between bg-slate-50 border-b px-6 py-4 h-16">
+      <h1 className="flex items-center gap-3 text-base font-semibold text-slate-600">
+        {title}
+        {showTodayButton &&
+          (todayButton ? (
+            todayButton({ onToday })
+          ) : (
+            <button
+              className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 rounded-md px-3"
+              onClick={onToday}
+            >
+              Today
+            </button>
+          ))}
+      </h1>
+      <div className="flex items-center space-x-5">
+        <div className="flex space-x-1">
+          {showPrevButton &&
+            (prevButton ? (
+              prevButton({ onPrev })
+            ) : (
+              <button
+                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
+                onClick={onPrev}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 15 15"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8.84182 3.13514C9.04327 3.32401 9.05348 3.64042 8.86462 3.84188L5.43521 7.49991L8.86462 11.1579C9.05348 11.3594 9.04327 11.6758 8.84182 11.8647C8.64036 12.0535 8.32394 12.0433 8.13508 11.8419L4.38508 7.84188C4.20477 7.64955 4.20477 7.35027 4.38508 7.15794L8.13508 3.15794C8.32394 2.95648 8.64036 2.94628 8.84182 3.13514Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </button>
+            ))}
+          {showNextButton &&
+            (nextButton ? (
+              nextButton({ onNext })
+            ) : (
+              <button
+                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
+                onClick={onNext}
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 15 15"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M6.1584 3.13508C6.35985 2.94621 6.67627 2.95642 6.86514 3.15788L10.6151 7.15788C10.7954 7.3502 10.7954 7.64949 10.6151 7.84182L6.86514 11.8418C6.67627 12.0433 6.35985 12.0535 6.1584 11.8646C5.95694 11.6757 5.94673 11.3593 6.1356 11.1579L9.565 7.49985L6.1356 3.84182C5.94673 3.64036 5.95694 3.32394 6.1584 3.13508Z"
+                    fill="currentColor"
+                    fillRule="evenodd"
+                    clipRule="evenodd"
+                  ></path>
+                </svg>
+              </button>
+            ))}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/WeekView/Header.tsx
+++ b/src/components/WeekView/Header.tsx
@@ -9,6 +9,7 @@ export default function Header({
                                    title,
                                    showTodayButton = true,
                                    todayButton,
+                                   onReload,
                                    onToday,
                                    showPrevButton = true,
                                    prevButton,
@@ -23,6 +24,7 @@ export default function Header({
     title: ReactNode;
     showTodayButton?: boolean;
     todayButton?: ({onToday}: { onToday?: () => void }) => ReactNode;
+    onReload?: () => void;
     onToday?: () => void;
     showPrevButton?: boolean;
     prevButton?: ({onPrev}: { onPrev?: () => void }) => ReactNode;
@@ -60,6 +62,11 @@ export default function Header({
             <h1 className="flex absolute left-[50%] translate-x-[-50%] items-center gap-3 text-base font-semibold text-slate-600">
                 {title}
             </h1>
+            <button
+                className="inline-flex mr-auto ml-5 items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 rounded-md px-3"
+                onClick={onReload}>
+                רענן
+            </button>
             {showTodayButton &&
                 (todayButton ? (
                     todayButton({onToday})

--- a/src/components/WeekView/Header.tsx
+++ b/src/components/WeekView/Header.tsx
@@ -1,96 +1,128 @@
-import { ReactNode } from "react";
+import {ReactNode} from "react";
+import {MenuItem, Select} from '@mui/material';
+import {Barber} from '@/entities/Barber';
 
 export default function Header({
-  title,
-  showTodayButton = true,
-  todayButton,
-  onToday,
-  showPrevButton = true,
-  prevButton,
-  onPrev,
-  showNextButton = true,
-  nextButton,
-  onNext,
-}: {
-  title: ReactNode;
-  showTodayButton?: boolean;
-  todayButton?: ({ onToday }: { onToday?: () => void }) => ReactNode;
-  onToday?: () => void;
-  showPrevButton?: boolean;
-  prevButton?: ({ onPrev }: { onPrev?: () => void }) => ReactNode;
-  onPrev?: () => void;
-  showNextButton?: boolean;
-  nextButton?: ({ onNext }: { onNext?: () => void }) => ReactNode;
-  onNext?: () => void;
+                                   selectedBarberId,
+                                   barbers,
+                                   onBarberChange,
+                                   title,
+                                   showTodayButton = true,
+                                   todayButton,
+                                   onToday,
+                                   showPrevButton = true,
+                                   prevButton,
+                                   onPrev,
+                                   showNextButton = true,
+                                   nextButton,
+                                   onNext,
+                               }: {
+    selectedBarberId?: string;
+    barbers?: Barber[];
+    onBarberChange?: (barber: Barber) => void;
+    title: ReactNode;
+    showTodayButton?: boolean;
+    todayButton?: ({onToday}: { onToday?: () => void }) => ReactNode;
+    onToday?: () => void;
+    showPrevButton?: boolean;
+    prevButton?: ({onPrev}: { onPrev?: () => void }) => ReactNode;
+    onPrev?: () => void;
+    showNextButton?: boolean;
+    nextButton?: ({onNext}: { onNext?: () => void }) => ReactNode;
+    onNext?: () => void;
 }) {
-  return (
-    <header className="flex items-center justify-between bg-slate-50 border-b px-6 py-4 h-16">
-      <h1 className="flex items-center gap-3 text-base font-semibold text-slate-600">
-        {title}
-        {showTodayButton &&
-          (todayButton ? (
-            todayButton({ onToday })
-          ) : (
-            <button
-              className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 rounded-md px-3"
-              onClick={onToday}
-            >
-              Today
-            </button>
-          ))}
-      </h1>
-      <div className="flex items-center space-x-5">
-        <div className="flex space-x-1">
-          {showPrevButton &&
-            (prevButton ? (
-              prevButton({ onPrev })
-            ) : (
-              <button
-                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
-                onClick={onPrev}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 15 15"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M8.84182 3.13514C9.04327 3.32401 9.05348 3.64042 8.86462 3.84188L5.43521 7.49991L8.86462 11.1579C9.05348 11.3594 9.04327 11.6758 8.84182 11.8647C8.64036 12.0535 8.32394 12.0433 8.13508 11.8419L4.38508 7.84188C4.20477 7.64955 4.20477 7.35027 4.38508 7.15794L8.13508 3.15794C8.32394 2.95648 8.64036 2.94628 8.84182 3.13514Z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-              </button>
-            ))}
-          {showNextButton &&
-            (nextButton ? (
-              nextButton({ onNext })
-            ) : (
-              <button
-                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
-                onClick={onNext}
-              >
-                <svg
-                  width="16"
-                  height="16"
-                  viewBox="0 0 15 15"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M6.1584 3.13508C6.35985 2.94621 6.67627 2.95642 6.86514 3.15788L10.6151 7.15788C10.7954 7.3502 10.7954 7.64949 10.6151 7.84182L6.86514 11.8418C6.67627 12.0433 6.35985 12.0535 6.1584 11.8646C5.95694 11.6757 5.94673 11.3593 6.1356 11.1579L9.565 7.49985L6.1356 3.84182C5.94673 3.64036 5.95694 3.32394 6.1584 3.13508Z"
-                    fill="currentColor"
-                    fillRule="evenodd"
-                    clipRule="evenodd"
-                  ></path>
-                </svg>
-              </button>
-            ))}
-        </div>
-      </div>
-    </header>
-  );
+    return (
+        <header className="flex items-center justify-between bg-slate-50 border-b px-6 py-4 h-16">
+            {
+                barbers &&
+                <div className={"ml-10 w-[150px]"}>
+                    <Select fullWidth className={"h-[32px]!important"}
+                            sx={{
+                                "& .MuiInputBase-input": {
+                                    padding: '4.5px !important',
+                                },
+                                "& .MuiSelect-select.MuiSelect-outlined": {
+                                    paddingLeft: '32px !important',
+                                    paddingRight: '14px !important',
+                                },
+                                "& .MuiSvgIcon-root": {
+                                    right: "unset",
+                                    left: "7px",
+                                },
+                            }}
+                            value={selectedBarberId}
+                            onChange={(e) => onBarberChange(barbers.find((b) => b.id === e.target.value))}>
+                        {barbers.map((b) => <MenuItem key={b.id}
+                                                      value={b.id}>{`${b.firstName} ${b.lastName}`}</MenuItem>)}
+                    </Select>
+                </div>
+            }
+            <h1 className="flex absolute left-[50%] translate-x-[-50%] items-center gap-3 text-base font-semibold text-slate-600">
+                {title}
+            </h1>
+            {showTodayButton &&
+                (todayButton ? (
+                    todayButton({onToday})
+                ) : (
+                    <button
+                        className="inline-flex mr-auto ml-5 items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 rounded-md px-3"
+                        onClick={onToday}
+                    >
+                        חזרה להיום
+                    </button>
+                ))}
+            <div className="flex items-center space-x-5">
+                <div className="flex space-x-1">
+                    {showPrevButton &&
+                        (prevButton ? (
+                            prevButton({onPrev})
+                        ) : (
+                            <button
+                                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
+                                onClick={onPrev}
+                            >
+                                <svg
+                                    width="16"
+                                    height="16"
+                                    viewBox="0 0 15 15"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="M6.1584 3.13508C6.35985 2.94621 6.67627 2.95642 6.86514 3.15788L10.6151 7.15788C10.7954 7.3502 10.7954 7.64949 10.6151 7.84182L6.86514 11.8418C6.67627 12.0433 6.35985 12.0535 6.1584 11.8646C5.95694 11.6757 5.94673 11.3593 6.1356 11.1579L9.565 7.49985L6.1356 3.84182C5.94673 3.64036 5.95694 3.32394 6.1584 3.13508Z"
+                                        fill="currentColor"
+                                        fillRule="evenodd"
+                                        clipRule="evenodd"
+                                    ></path>
+                                </svg>
+                            </button>
+                        ))}
+                    {showNextButton &&
+                        (nextButton ? (
+                            nextButton({onNext})
+                        ) : (
+                            <button
+                                className="inline-flex items-center justify-center text-xs transition-colors font-normal border border-slate-200 bg-white hover:bg-slate-50 h-8 w-8 rounded-md"
+                                onClick={onNext}
+                            >
+                                <svg
+                                    width="16"
+                                    height="16"
+                                    viewBox="0 0 15 15"
+                                    fill="none"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="M8.84182 3.13514C9.04327 3.32401 9.05348 3.64042 8.86462 3.84188L5.43521 7.49991L8.86462 11.1579C9.05348 11.3594 9.04327 11.6758 8.84182 11.8647C8.64036 12.0535 8.32394 12.0433 8.13508 11.8419L4.38508 7.84188C4.20477 7.64955 4.20477 7.35027 4.38508 7.15794L8.13508 3.15794C8.32394 2.95648 8.64036 2.94628 8.84182 3.13514Z"
+                                        fill="currentColor"
+                                        fillRule="evenodd"
+                                        clipRule="evenodd"
+                                    ></path>
+                                </svg>
+                            </button>
+                        ))}
+                </div>
+            </div>
+        </header>
+    );
 }

--- a/src/components/WeekView/WeekView.tsx
+++ b/src/components/WeekView/WeekView.tsx
@@ -1,6 +1,6 @@
 import {Day, isSameWeek, Locale} from "date-fns";
 
-import useWeekView, {Cell} from "./use-weekview";
+import useWeekView, {Cell, WorkingHours} from "./use-weekview";
 import Header from "./Header";
 import DaysHeader from "./DaysHeader";
 import Grid from "./Grid";
@@ -19,6 +19,7 @@ export default function WeekView({
                                      barbers,
                                      onBarberChange,
                                      initialDate,
+                                     getWeeklySchedule,
                                      minuteStep = 30,
                                      weekStartsOn = 1,
                                      locale,
@@ -34,6 +35,7 @@ export default function WeekView({
     barbers?: Barber[];
     onBarberChange?: (barber: Barber) => void;
     initialDate?: Date;
+    getWeeklySchedule?: (startDayOfWeek: Date) => WorkingHours[];
     minuteStep?: number;
     weekStartsOn?: Day;
     locale?: Locale;
@@ -45,8 +47,9 @@ export default function WeekView({
     onCellClick?: (cell: Cell) => void;
     onEventClick?: (event: Event) => void;
 }) {
-    const {days:sevenDays, nextWeek, previousWeek, goToToday, viewTitle} = useWeekView({
+    const {days: sevenDays, nextWeek, previousWeek, goToToday, viewTitle} = useWeekView({
         initialDate,
+        getWeeklySchedule,
         minuteStep,
         weekStartsOn,
         locale,

--- a/src/components/WeekView/WeekView.tsx
+++ b/src/components/WeekView/WeekView.tsx
@@ -1,0 +1,89 @@
+import {Day, isSameWeek, Locale} from "date-fns";
+
+import useWeekView, { Cell } from "./use-weekview";
+import Header from "./Header";
+import DaysHeader from "./DaysHeader";
+import Grid from "./Grid";
+import EventGrid from "./EventGrid";
+
+export type Event = {
+  id: string;
+  title: string;
+  startDate: Date;
+  endDate: Date;
+};
+
+export default function WeekView({
+  initialDate,
+  minuteStep = 30,
+  weekStartsOn = 1,
+  locale,
+  rowHeight = 56,
+  disabledCell,
+  disabledDay,
+  disabledWeek,
+  events,
+  onCellClick,
+  onEventClick,
+}: {
+  initialDate?: Date;
+  minuteStep?: number;
+  weekStartsOn?: Day;
+  locale?: Locale;
+  rowHeight?: number;
+  disabledCell?: (date: Date) => boolean;
+  disabledDay?: (date: Date) => boolean;
+  disabledWeek?: (startDayOfWeek: Date) => boolean;
+  events?: Event[];
+  onCellClick?: (cell: Cell) => void;
+  onEventClick?: (event: Event) => void;
+}) {
+  const { days, nextWeek, previousWeek, goToToday, viewTitle } = useWeekView({
+    initialDate,
+    minuteStep,
+    weekStartsOn,
+    locale,
+    disabledCell,
+    disabledDay,
+    disabledWeek,
+  });
+
+  return (
+    <div className="flex flex-col overflow-hidden bg-white h-[70vh] rounded-md border-[#394f4455] border-1" dir={"ltr"}>
+      <Header
+        title={viewTitle}
+        onNext={nextWeek}
+        onPrev={previousWeek}
+        onToday={goToToday}
+        showTodayButton={!isSameWeek(days[0].date, new Date())}
+      />
+      <div className="flex flex-col flex-1 overflow-hidden select-none">
+        <div className="flex flex-col flex-1 isolate overflow-auto">
+          <div className="flex flex-col flex-none min-w-[700px]">
+            <DaysHeader days={days} />
+            <div className="grid grid-cols-1 grid-rows-1">
+              <div className="row-start-1 col-start-1">
+                <Grid
+                  days={days}
+                  rowHeight={rowHeight}
+                  onCellClick={onCellClick}
+                />
+              </div>
+              <div className="row-start-1 col-start-1">
+                <EventGrid
+                  days={days}
+                  events={events}
+                  weekStartsOn={weekStartsOn}
+                  locale={locale}
+                  minuteStep={minuteStep}
+                  rowHeight={rowHeight}
+                  onEventClick={onEventClick}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/WeekView/WeekView.tsx
+++ b/src/components/WeekView/WeekView.tsx
@@ -6,6 +6,7 @@ import DaysHeader from "./DaysHeader";
 import Grid from "./Grid";
 import EventGrid from "./EventGrid";
 import {Barber} from "@/entities/Barber";
+import {useEffect} from 'react';
 
 export type Event = {
     id: string;
@@ -16,6 +17,7 @@ export type Event = {
 
 export default function WeekView({
                                      selectedBarberId,
+                                     onStartOfWeekChange,
                                      barbers,
                                      onBarberChange,
                                      initialDate,
@@ -28,10 +30,12 @@ export default function WeekView({
                                      disabledDay,
                                      disabledWeek,
                                      events,
+                                     onReload,
                                      onCellClick,
                                      onEventClick,
                                  }: {
     selectedBarberId?: string;
+    onStartOfWeekChange?: (startOfTheWeek: Date) => void,
     barbers?: Barber[];
     onBarberChange?: (barber: Barber) => void;
     initialDate?: Date;
@@ -44,10 +48,11 @@ export default function WeekView({
     disabledDay?: (date: Date) => boolean;
     disabledWeek?: (startDayOfWeek: Date) => boolean;
     events?: Event[];
+    onReload?: () => void,
     onCellClick?: (cell: Cell) => void;
     onEventClick?: (event: Event) => void;
 }) {
-    const {days: sevenDays, nextWeek, previousWeek, goToToday, viewTitle} = useWeekView({
+    const {startOfTheWeek, days: sevenDays, nextWeek, previousWeek, goToToday, viewTitle} = useWeekView({
         initialDate,
         getWeeklySchedule,
         minuteStep,
@@ -58,6 +63,10 @@ export default function WeekView({
         disabledWeek,
     });
 
+    useEffect(() => {
+        onStartOfWeekChange?.(startOfTheWeek);
+    }, [startOfTheWeek, onStartOfWeekChange]);
+
     const days = sevenDays.toSpliced(-1, 1);
 
     return (
@@ -67,6 +76,7 @@ export default function WeekView({
                 onBarberChange={onBarberChange}
                 barbers={barbers}
                 title={viewTitle}
+                onReload={onReload}
                 onNext={nextWeek}
                 onPrev={previousWeek}
                 onToday={goToToday}

--- a/src/components/WeekView/WeekView.tsx
+++ b/src/components/WeekView/WeekView.tsx
@@ -1,89 +1,101 @@
 import {Day, isSameWeek, Locale} from "date-fns";
 
-import useWeekView, { Cell } from "./use-weekview";
+import useWeekView, {Cell} from "./use-weekview";
 import Header from "./Header";
 import DaysHeader from "./DaysHeader";
 import Grid from "./Grid";
 import EventGrid from "./EventGrid";
+import {Barber} from "@/entities/Barber";
 
 export type Event = {
-  id: string;
-  title: string;
-  startDate: Date;
-  endDate: Date;
+    id: string;
+    title: string;
+    startDate: Date;
+    endDate: Date;
 };
 
 export default function WeekView({
-  initialDate,
-  minuteStep = 30,
-  weekStartsOn = 1,
-  locale,
-  rowHeight = 56,
-  disabledCell,
-  disabledDay,
-  disabledWeek,
-  events,
-  onCellClick,
-  onEventClick,
-}: {
-  initialDate?: Date;
-  minuteStep?: number;
-  weekStartsOn?: Day;
-  locale?: Locale;
-  rowHeight?: number;
-  disabledCell?: (date: Date) => boolean;
-  disabledDay?: (date: Date) => boolean;
-  disabledWeek?: (startDayOfWeek: Date) => boolean;
-  events?: Event[];
-  onCellClick?: (cell: Cell) => void;
-  onEventClick?: (event: Event) => void;
+                                     selectedBarberId,
+                                     barbers,
+                                     onBarberChange,
+                                     initialDate,
+                                     minuteStep = 30,
+                                     weekStartsOn = 1,
+                                     locale,
+                                     rowHeight = 56,
+                                     disabledCell,
+                                     disabledDay,
+                                     disabledWeek,
+                                     events,
+                                     onCellClick,
+                                     onEventClick,
+                                 }: {
+    selectedBarberId?: string;
+    barbers?: Barber[];
+    onBarberChange?: (barber: Barber) => void;
+    initialDate?: Date;
+    minuteStep?: number;
+    weekStartsOn?: Day;
+    locale?: Locale;
+    rowHeight?: number;
+    disabledCell?: (date: Date) => boolean;
+    disabledDay?: (date: Date) => boolean;
+    disabledWeek?: (startDayOfWeek: Date) => boolean;
+    events?: Event[];
+    onCellClick?: (cell: Cell) => void;
+    onEventClick?: (event: Event) => void;
 }) {
-  const { days, nextWeek, previousWeek, goToToday, viewTitle } = useWeekView({
-    initialDate,
-    minuteStep,
-    weekStartsOn,
-    locale,
-    disabledCell,
-    disabledDay,
-    disabledWeek,
-  });
+    const {days:sevenDays, nextWeek, previousWeek, goToToday, viewTitle} = useWeekView({
+        initialDate,
+        minuteStep,
+        weekStartsOn,
+        locale,
+        disabledCell,
+        disabledDay,
+        disabledWeek,
+    });
 
-  return (
-    <div className="flex flex-col overflow-hidden bg-white h-[70vh] rounded-md border-[#394f4455] border-1" dir={"ltr"}>
-      <Header
-        title={viewTitle}
-        onNext={nextWeek}
-        onPrev={previousWeek}
-        onToday={goToToday}
-        showTodayButton={!isSameWeek(days[0].date, new Date())}
-      />
-      <div className="flex flex-col flex-1 overflow-hidden select-none">
-        <div className="flex flex-col flex-1 isolate overflow-auto">
-          <div className="flex flex-col flex-none min-w-[700px]">
-            <DaysHeader days={days} />
-            <div className="grid grid-cols-1 grid-rows-1">
-              <div className="row-start-1 col-start-1">
-                <Grid
-                  days={days}
-                  rowHeight={rowHeight}
-                  onCellClick={onCellClick}
-                />
-              </div>
-              <div className="row-start-1 col-start-1">
-                <EventGrid
-                  days={days}
-                  events={events}
-                  weekStartsOn={weekStartsOn}
-                  locale={locale}
-                  minuteStep={minuteStep}
-                  rowHeight={rowHeight}
-                  onEventClick={onEventClick}
-                />
-              </div>
+    const days = sevenDays.toSpliced(-1, 1);
+
+    return (
+        <div className="flex flex-col overflow-hidden bg-white h-[70vh] rounded-md border-[#394f4455] border-1">
+            <Header
+                selectedBarberId={selectedBarberId}
+                onBarberChange={onBarberChange}
+                barbers={barbers}
+                title={viewTitle}
+                onNext={nextWeek}
+                onPrev={previousWeek}
+                onToday={goToToday}
+                showTodayButton={!isSameWeek(days[0].date, new Date())}
+            />
+            <div className="flex flex-col flex-1 overflow-hidden select-none">
+                <div className="flex flex-col flex-1 isolate overflow-auto" dir={"ltr"}>
+                    <div className="flex flex-col flex-none" dir={"rtl"}>
+                        <DaysHeader days={days}/>
+                        <div className="grid grid-cols-1 grid-rows-1 flex-1">
+                            <div className="row-start-1 col-start-1">
+                                <Grid
+                                    days={days}
+                                    rowHeight={rowHeight}
+                                    onCellClick={onCellClick}
+                                />
+                            </div>
+                            <div className="row-start-1 col-start-1">
+                                <EventGrid
+                                    days={days}
+                                    events={events}
+                                    weekStartsOn={weekStartsOn}
+                                    locale={locale}
+                                    minuteStep={minuteStep}
+                                    rowHeight={rowHeight}
+                                    onEventClick={onEventClick}
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 }

--- a/src/components/WeekView/use-weekview.ts
+++ b/src/components/WeekView/use-weekview.ts
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import {
+  addDays,
+  eachDayOfInterval,
+  eachMinuteOfInterval,
+  endOfDay,
+  startOfDay,
+  startOfWeek,
+  isToday,
+  format,
+  Day,
+  Locale,
+  isSameMonth,
+  isSameYear,
+} from "date-fns";
+
+export default function useWeekView({
+  initialDate,
+  minuteStep = 30,
+  weekStartsOn = 1,
+  locale,
+  disabledCell,
+  disabledDay,
+  disabledWeek,
+}:
+  | {
+      initialDate?: Date;
+      minuteStep?: number;
+      weekStartsOn?: Day;
+      locale?: Locale;
+      disabledCell?: (date: Date) => boolean;
+      disabledDay?: (date: Date) => boolean;
+      disabledWeek?: (startDayOfWeek: Date) => boolean;
+    }
+  | undefined = {}) {
+  const [startOfTheWeek, setStartOfTheWeek] = useState(
+    startOfWeek(startOfDay(initialDate || new Date()), { weekStartsOn })
+  );
+
+  const nextWeek = () => {
+    const nextWeek = addDays(startOfTheWeek, 7);
+    if (disabledWeek && disabledWeek(nextWeek)) return;
+    setStartOfTheWeek(nextWeek);
+  };
+
+  const previousWeek = () => {
+    const previousWeek = addDays(startOfTheWeek, -7);
+    if (disabledWeek && disabledWeek(previousWeek)) return;
+    setStartOfTheWeek(previousWeek);
+  };
+
+  const goToToday = () => {
+    setStartOfTheWeek(startOfWeek(startOfDay(new Date()), { weekStartsOn }));
+  };
+
+  const days = eachDayOfInterval({
+    start: startOfTheWeek,
+    end: addDays(startOfTheWeek, 6),
+  }).map((day) => ({
+    date: day,
+    isToday: isToday(day),
+    name: format(day, "EEEE", { locale }),
+    shortName: format(day, "EEE", { locale }),
+    dayOfMonth: format(day, "d", { locale }),
+    dayOfMonthWithZero: format(day, "dd", { locale }),
+    dayOfMonthWithSuffix: format(day, "do", { locale }),
+    disabled: disabledDay ? disabledDay(day) : false,
+    cells: eachMinuteOfInterval(
+      {
+        start: startOfDay(day),
+        end: endOfDay(day),
+      },
+      {
+        step: minuteStep,
+      }
+    ).map((hour) => ({
+      date: hour,
+      hour: format(hour, "HH", { locale }),
+      minute: format(hour, "mm", { locale }),
+      hourAndMinute: format(hour, "HH:mm", { locale }),
+      disabled: disabledCell ? disabledCell(hour) : false,
+    })),
+  }));
+
+  const isAllSameYear = isSameYear(days[0].date, days[days.length - 1].date);
+  const isAllSameMonth = isSameMonth(days[0].date, days[days.length - 1].date);
+
+  let viewTitle = '';
+  if (isAllSameMonth) viewTitle = format(days[0].date, "MMMM yyyy", { locale });
+  else if (isAllSameYear)
+    viewTitle = `${format(days[0].date, "MMM", { locale })} - ${format(
+      days[days.length - 1].date,
+      "MMM",
+      { locale }
+    )} ${format(days[0].date, "yyyy", { locale })}`;
+  else
+    viewTitle = `${format(days[0].date, "MMM yyyy", { locale })} - ${format(
+      days[days.length - 1].date,
+      "MMM yyyy",
+      { locale }
+    )}`;
+
+  const weekNumber = format(days[0].date, "w", { locale });
+
+  return {
+    nextWeek,
+    previousWeek,
+    goToToday,
+    days,
+    weekNumber,
+    viewTitle,
+  };
+}
+
+export type Days = ReturnType<typeof useWeekView>["days"];
+export type Cell = Days[number]["cells"][number];

--- a/src/components/WeekView/use-weekview.ts
+++ b/src/components/WeekView/use-weekview.ts
@@ -66,8 +66,6 @@ export default function useWeekView({
         }
     }, [getWeeklySchedule, startOfTheWeek]);
 
-    console.log(weeklySchedule);
-
     const weekDaysAmount = weeklySchedule.weekDaysAmount ?? DEFAULT_WEEK_DAYS_AMOUNT;
 
     const nextWeek = () => {
@@ -143,6 +141,7 @@ export default function useWeekView({
     const weekNumber = format(days[0].date, "w", {locale});
 
     return {
+        startOfTheWeek,
         nextWeek,
         previousWeek,
         goToToday,

--- a/src/components/WeekView/use-weekview.ts
+++ b/src/components/WeekView/use-weekview.ts
@@ -1,115 +1,155 @@
-import { useState } from "react";
+import {useMemo, useState} from "react";
 import {
-  addDays,
-  eachDayOfInterval,
-  eachMinuteOfInterval,
-  endOfDay,
-  startOfDay,
-  startOfWeek,
-  isToday,
-  format,
-  Day,
-  Locale,
-  isSameMonth,
-  isSameYear,
+    addDays,
+    Day,
+    eachDayOfInterval,
+    eachMinuteOfInterval,
+    format,
+    isSameMonth,
+    isSameYear,
+    isToday,
+    Locale,
+    setHours,
+    setMinutes,
+    startOfDay,
+    startOfWeek,
 } from "date-fns";
 
+export type WorkingHours = { start: string, end: string };
+
+const DEFAULT_WEEK_DAYS_AMOUNT = 7;
+const DEFAULT_DAY_START = '00:00';
+const DEFAULT_DAY_END = '23:59';
+
 export default function useWeekView({
-  initialDate,
-  minuteStep = 30,
-  weekStartsOn = 1,
-  locale,
-  disabledCell,
-  disabledDay,
-  disabledWeek,
-}:
-  | {
-      initialDate?: Date;
-      minuteStep?: number;
-      weekStartsOn?: Day;
-      locale?: Locale;
-      disabledCell?: (date: Date) => boolean;
-      disabledDay?: (date: Date) => boolean;
-      disabledWeek?: (startDayOfWeek: Date) => boolean;
-    }
-  | undefined = {}) {
-  const [startOfTheWeek, setStartOfTheWeek] = useState(
-    startOfWeek(startOfDay(initialDate || new Date()), { weekStartsOn })
-  );
+                                        initialDate,
+                                        minuteStep = 30,
+                                        weekStartsOn = 1,
+                                        locale,
+                                        getWeeklySchedule,
+                                        disabledCell,
+                                        disabledDay,
+                                        disabledWeek,
+                                    }:
+                                        | {
+                                        initialDate?: Date;
+                                        minuteStep?: number;
+                                        weekStartsOn?: Day;
+                                        locale?: Locale;
+                                        getWeeklySchedule?: (startDayOfWeek: Date) => WorkingHours[];
+                                        disabledCell?: (date: Date) => boolean;
+                                        disabledDay?: (date: Date) => boolean;
+                                        disabledWeek?: (startDayOfWeek: Date) => boolean;
+                                    }
+                                        | undefined = {}) {
+    const [startOfTheWeek, setStartOfTheWeek] = useState(
+        startOfWeek(startOfDay(initialDate || new Date()), {weekStartsOn})
+    );
 
-  const nextWeek = () => {
-    const nextWeek = addDays(startOfTheWeek, 7);
-    if (disabledWeek && disabledWeek(nextWeek)) return;
-    setStartOfTheWeek(nextWeek);
-  };
+    const weeklySchedule = useMemo(() => {
+        const schedule = getWeeklySchedule?.(startOfTheWeek);
+        const weekDaysAmount = schedule?.length;
+        const extremities = schedule?.length ?
+            {
+                earliestStart: schedule.map((day) => day.start ?? DEFAULT_DAY_START).reduce((prev, curr) => curr < prev ? curr : prev).split(':').map(Number),
+                latestEnd: schedule.map((day) => day.end ?? DEFAULT_DAY_END).reduce((prev, curr) => curr > prev ? curr : prev).split(':').map(Number),
+            } :
+            {
+                earliestStart: DEFAULT_DAY_START.split(':').map(Number),
+                latestEnd: DEFAULT_DAY_END.split(':').map(Number),
+            };
 
-  const previousWeek = () => {
-    const previousWeek = addDays(startOfTheWeek, -7);
-    if (disabledWeek && disabledWeek(previousWeek)) return;
-    setStartOfTheWeek(previousWeek);
-  };
+        return {
+            weekDaysAmount,
+            extremities,
+            schedule,
+        }
+    }, [getWeeklySchedule, startOfTheWeek]);
 
-  const goToToday = () => {
-    setStartOfTheWeek(startOfWeek(startOfDay(new Date()), { weekStartsOn }));
-  };
+    console.log(weeklySchedule);
 
-  const days = eachDayOfInterval({
-    start: startOfTheWeek,
-    end: addDays(startOfTheWeek, 6),
-  }).map((day) => ({
-    date: day,
-    isToday: isToday(day),
-    name: format(day, "EEEE", { locale }),
-    shortName: format(day, "EEE", { locale }),
-    dayOfMonth: format(day, "d", { locale }),
-    dayOfMonthWithZero: format(day, "dd", { locale }),
-    dayOfMonthWithSuffix: format(day, "do", { locale }),
-    disabled: disabledDay ? disabledDay(day) : false,
-    cells: eachMinuteOfInterval(
-      {
-        start: startOfDay(day),
-        end: endOfDay(day),
-      },
-      {
-        step: minuteStep,
-      }
-    ).map((hour) => ({
-      date: hour,
-      hour: format(hour, "HH", { locale }),
-      minute: format(hour, "mm", { locale }),
-      hourAndMinute: format(hour, "HH:mm", { locale }),
-      disabled: disabledCell ? disabledCell(hour) : false,
-    })),
-  }));
+    const weekDaysAmount = weeklySchedule.weekDaysAmount ?? DEFAULT_WEEK_DAYS_AMOUNT;
 
-  const isAllSameYear = isSameYear(days[0].date, days[days.length - 1].date);
-  const isAllSameMonth = isSameMonth(days[0].date, days[days.length - 1].date);
+    const nextWeek = () => {
+        const nextWeek = addDays(startOfTheWeek, weekDaysAmount);
+        if (disabledWeek && disabledWeek(nextWeek)) return;
+        setStartOfTheWeek(nextWeek);
+    };
 
-  let viewTitle = '';
-  if (isAllSameMonth) viewTitle = format(days[0].date, "MMMM yyyy", { locale });
-  else if (isAllSameYear)
-    viewTitle = `${format(days[0].date, "MMM", { locale })} - ${format(
-      days[days.length - 1].date,
-      "MMM",
-      { locale }
-    )} ${format(days[0].date, "yyyy", { locale })}`;
-  else
-    viewTitle = `${format(days[0].date, "MMM yyyy", { locale })} - ${format(
-      days[days.length - 1].date,
-      "MMM yyyy",
-      { locale }
-    )}`;
+    const previousWeek = () => {
+        const previousWeek = addDays(startOfTheWeek, -weekDaysAmount);
+        if (disabledWeek && disabledWeek(previousWeek)) return;
+        setStartOfTheWeek(previousWeek);
+    };
 
-  const weekNumber = format(days[0].date, "w", { locale });
+    const goToToday = () => {
+        setStartOfTheWeek(startOfWeek(startOfDay(new Date()), {weekStartsOn}));
+    };
 
-  return {
-    nextWeek,
-    previousWeek,
-    goToToday,
-    days,
-    weekNumber,
-    viewTitle,
-  };
+    const days = eachDayOfInterval({
+        start: startOfTheWeek,
+        end: addDays(startOfTheWeek, weekDaysAmount),
+    }).map((day) => {
+        const [earliestHours, earliestMinutes] = weeklySchedule.extremities.earliestStart;
+        const [latestHours, latestMinutes] = weeklySchedule.extremities.latestEnd;
+        const earliestStart = setMinutes(setHours(day, earliestHours), earliestMinutes);
+        const latestEnd = setMinutes(setHours(day, latestHours), latestMinutes);
+
+        return {
+            date: day,
+            isToday: isToday(day),
+            name: format(day, "EEEE", {locale}),
+            shortName: format(day, "EEE", {locale}),
+            dayOfMonth: format(day, "d", {locale}),
+            dayOfMonthWithZero: format(day, "dd", {locale}),
+            dayOfMonthWithSuffix: format(day, "do", {locale}),
+            disabled: disabledDay ? disabledDay(day) : false,
+            cells: eachMinuteOfInterval(
+                {
+                    start: earliestStart,
+                    end: latestEnd,
+                },
+                {
+                    step: minuteStep,
+                }
+            ).toSpliced(-1, 1).map((hour) => ({
+                date: hour,
+                hour: format(hour, "HH", {locale}),
+                minute: format(hour, "mm", {locale}),
+                hourAndMinute: format(hour, "HH:mm", {locale}),
+                disabled: disabledCell ? disabledCell(hour) : false,
+            })),
+        }
+    });
+
+    const isAllSameYear = isSameYear(days[0].date, days[days.length - 1].date);
+    const isAllSameMonth = isSameMonth(days[0].date, days[days.length - 1].date);
+
+    let viewTitle = '';
+    if (isAllSameMonth) viewTitle = format(days[0].date, "MMMM yyyy", {locale});
+    else if (isAllSameYear)
+        viewTitle = `${format(days[0].date, "MMM", {locale})} - ${format(
+            days[days.length - 1].date,
+            "MMM",
+            {locale}
+        )} ${format(days[0].date, "yyyy", {locale})}`;
+    else
+        viewTitle = `${format(days[0].date, "MMM yyyy", {locale})} - ${format(
+            days[days.length - 1].date,
+            "MMM yyyy",
+            {locale}
+        )}`;
+
+    const weekNumber = format(days[0].date, "w", {locale});
+
+    return {
+        nextWeek,
+        previousWeek,
+        goToToday,
+        days,
+        weekNumber,
+        viewTitle,
+    };
 }
 
 export type Days = ReturnType<typeof useWeekView>["days"];

--- a/src/entities/Appointment.js
+++ b/src/entities/Appointment.js
@@ -15,11 +15,12 @@ export class Appointment {
         this.barber = data.barber;
     }
 
-    static async getAll({barberId, date} = {}) {
+    static async get({barberId, startDate, endDate} = {}) {
         try {
             const url = new URL('/api/appointments', window.location.origin);
             if (barberId) url.searchParams.append('barberId', barberId);
-            if (date) url.searchParams.append('date', date);
+            if (startDate) url.searchParams.append('startDate', startDate);
+            if (endDate) url.searchParams.append('endDate', endDate);
 
             const response = await fetch(url);
             if (!response.ok) throw new Error('Failed to fetch appointments');

--- a/src/lib/he-IL-localize.ts
+++ b/src/lib/he-IL-localize.ts
@@ -1,0 +1,95 @@
+import type { Localize } from 'date-fns/locale/types'
+
+const localizeIL: Localize = {
+    ordinalNumber: (dirtyNumber) => {
+        const number = Number(dirtyNumber)
+        return number.toString()
+    },
+
+    era: (dirtyIndex, { width }) => {
+        const values = {
+            narrow: ['לפנה״ס', 'לסה״נ'],
+            abbreviated: ['לפנה״ס', 'לסה״נ'],
+            wide: ['לפני הספירה', 'לספירה']
+        }
+
+        return values[width][dirtyIndex]
+    },
+
+    quarter: (dirtyQuarter, { width }) => {
+        const quarter = Number(dirtyQuarter)
+        const values = {
+            narrow: ['1', '2', '3', '4'],
+            abbreviated: ['רבעון 1', 'רבעון 2', 'רבעון 3', 'רבעון 4'],
+            wide: ['רבעון ראשון', 'רבעון שני', 'רבעון שלישי', 'רבעון רביעי']
+        }
+
+        return values[width][quarter - 1]
+    },
+
+    month: (dirtyMonth, { width }) => {
+        const values = {
+            narrow: ['י', 'פ', 'מ', 'א', 'מ', 'י', 'י', 'א', 'ס', 'א', 'נ', 'ד'],
+            abbreviated: [
+                'ינו׳', 'פבר׳', 'מרץ', 'אפר׳', 'מאי', 'יוני',
+                'יולי', 'אוג׳', 'ספט׳', 'אוק׳', 'נוב׳', 'דצמ׳'
+            ],
+            wide: [
+                'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני',
+                'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר'
+            ]
+        }
+
+        return values[width][dirtyMonth]
+    },
+
+    day: (dirtyDay, { width }) => {
+        const values = {
+            narrow: ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ש'],
+            short: ['א׳', 'ב׳', 'ג׳', 'ד׳', 'ה׳', 'ו׳', 'ש׳'],
+            abbreviated: ['יום א׳', 'יום ב׳', 'יום ג׳', 'יום ד׳', 'יום ה׳', 'יום ו׳', 'שבת'],
+            wide: ['יום ראשון', 'יום שני', 'יום שלישי', 'יום רביעי', 'יום חמישי', 'יום שישי', 'יום שבת']
+        }
+
+        return values[width][dirtyDay]
+    },
+
+    dayPeriod: (dirtyType, { width }) => {
+        const values = {
+            narrow: {
+                am: 'לפנה״צ',
+                pm: 'אחה״צ',
+                midnight: 'חצות',
+                noon: 'צהריים',
+                morning: 'בוקר',
+                afternoon: 'אחר הצהריים',
+                evening: 'ערב',
+                night: 'לילה'
+            },
+            abbreviated: {
+                am: 'AM',
+                pm: 'PM',
+                midnight: 'חצות',
+                noon: 'צהריים',
+                morning: 'בוקר',
+                afternoon: 'אחה״צ',
+                evening: 'ערב',
+                night: 'לילה'
+            },
+            wide: {
+                am: 'לפני הצהריים',
+                pm: 'אחרי הצהריים',
+                midnight: 'חצות',
+                noon: 'צהריים',
+                morning: 'בבוקר',
+                afternoon: 'אחר הצהריים',
+                evening: 'בערב',
+                night: 'בלילה'
+            }
+        }
+
+        return values[width][dirtyType]
+    }
+}
+
+export default localizeIL;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/app/**/*.{js,ts,jsx,tsx}',     // App directory (App Router)
+    './src/components/**/*.{js,ts,jsx,tsx}', // Your component folders
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
- Installed tailwind
- Introduced new weekly calendar component
- Changed calendar to rtl and hebrew locale
- Reduced week days to 6
- Added a button to change barber for the calendar view
- Changed week view hour blocks displayed in schedule based on the earliest start and latest end hours of the works week (currently based on default barber work hours)
- Made it so that hour string is displayed on each block instead of only on round hours
- Adjusted colors of weekly calendar component for improved readability
- Appointments are displayed on the weekly calendar
- Appointments on the calendar can be edited
- Appointments can be added by clicking on empty calendar slots
- Calendar appointments are refreshed periodically
- Added a (throttled) manual refresh button