### PR TITLE
sprint1/hotfix/working-hours-and-calendar-bugs

### DIFF
--- a/src/app/management/calendar/page.jsx
+++ b/src/app/management/calendar/page.jsx
@@ -461,6 +461,14 @@ export default function CalendarManagement() {
                       locale={{code: 'he-IL', localize: localizeIL}}
                       weekStartsOn={0}
                       getWeeklySchedule={() => weeklySchedule ? Object.values(weeklySchedule ?? {}) : null}
+                      disabledDay={
+                          (date) => {
+                              console.log(weeklySchedule);
+                              const day = format(date, 'yyyy-MM-dd');
+
+                              return !weeklySchedule?.[day]?.start && !weeklySchedule?.[day]?.end;
+                          }
+                      }
                       windowCell={(date) => {
                           const day = format(date, 'yyyy-MM-dd');
                           const hour = format(date, 'HH:mm');

--- a/src/components/WeekView/Grid.tsx
+++ b/src/components/WeekView/Grid.tsx
@@ -31,7 +31,7 @@ export default function Grid({
                             gridColumnStart: dayIndex + 1,
                             gridColumnEnd: dayIndex + 2,
                         }}
-                        disabled={cell.disabled}
+                        disabled={day.disabled || cell.disabled}
                         onClick={() => onCellClick?.(cell)}>
                         {CellContent && CellContent(cell)}
                     </button>

--- a/src/components/WeekView/use-weekview.ts
+++ b/src/components/WeekView/use-weekview.ts
@@ -53,8 +53,8 @@ export default function useWeekView({
         const weekDaysAmount = schedule?.length;
         const extremities = schedule?.length ?
             {
-                earliestStart: schedule.map((day) => day.start ?? DEFAULT_DAY_START).reduce((prev, curr) => curr < prev ? curr : prev).split(':').map(Number),
-                latestEnd: schedule.map((day) => day.end ?? DEFAULT_DAY_END).reduce((prev, curr) => curr > prev ? curr : prev).split(':').map(Number),
+                earliestStart: schedule.filter((day) => day.start != null).map((day) => day.start).reduce((prev, curr) => curr < prev ? curr : prev).split(':').map(Number),
+                latestEnd: schedule.filter((day) => day.end != null).map((day) => day.end).reduce((prev, curr) => curr > prev ? curr : prev).split(':').map(Number),
             } :
             {
                 earliestStart: DEFAULT_DAY_START.split(':').map(Number),

--- a/src/components/WorkingHoursEditor.jsx
+++ b/src/components/WorkingHoursEditor.jsx
@@ -83,7 +83,7 @@ export default function WorkingHoursEditor({
                                             label="סיום"
                                             minutesStep={30}
                                             timeSteps={{minutes: 30}}
-                                            value={parse(workingHours[day.key]?.start || '09:00', 'HH:mm', new Date())}
+                                            value={parse(workingHours[day.key]?.end || '09:00', 'HH:mm', new Date())}
                                             onChange={(value) => handleTimeChange(day.key, 'start', format(value, 'HH:mm'))}
                                         />
                                     </Grid>


### PR DESCRIPTION
- Fixed working hours editor display where both start and end hour fields were displaying start hour
- Fixed calendar logic that determines work day extremities by filtering out null hours instead of using default start and end values
- Made it so that cells are disabled if the day they are part of is disabled