### PR TITLE
Bugfix

### DIFF
--- a/src/app/management/calendar/page.jsx
+++ b/src/app/management/calendar/page.jsx
@@ -171,7 +171,9 @@ export default function CalendarManagement() {
                     setBarbers(barbers);
                     setSelectedBarber(barbers.find((b) => b.id === userData.id));
                 } else if (userData.role === 'BARBER') {
-                    setSelectedBarber(await Barber.getById(userData.id));
+                    const barber = await Barber.getById(userData.id);
+                    setBarbers([barber]);
+                    setSelectedBarber(barber);
                 }
             })();
         }
@@ -270,7 +272,7 @@ export default function CalendarManagement() {
             item,
             `${item ? 'ערוך' : 'הוסף'} תור`,
             appointmentFields,
-            initialAppointmentFormData,
+            {...initialAppointmentFormData, barberId: selectedBarber.id},
             {
                 date,
                 time,

--- a/src/components/WeekView/EventGrid.tsx
+++ b/src/components/WeekView/EventGrid.tsx
@@ -27,7 +27,6 @@ export default function EventGrid({
             {(events || [])
                 .filter((event) => isSameWeek(days[0].date, event.startDate))
                 .map((event) => {
-                    console.log(Number(days[0].cells[0].minute))
                     const start =
                         Math.floor(((getHours(event.startDate) - Number(days[0].cells[0].hour)) * 60 +
                             (getMinutes(event.startDate) - Number(days[0].cells[0].minute))) / minuteStep) + 1;


### PR DESCRIPTION
- Appointments created through the calendar on an admin user are always assigned to the first barber in the list by default
- when creating appointment through the calendar on a barber user, the creation dialog was missing the available barbers