### PR TITLE
fix: prevent client crash from stale/corrupted userData cookie

### DIFF
--- a/src/app/api/auth/login/route.js
+++ b/src/app/api/auth/login/route.js
@@ -20,7 +20,7 @@ export async function POST() {
         });
 
         if (!user) {
-            NextResponse.json(
+            return NextResponse.json(
                 {message: 'wrong user credentials'},
                 {status: 401}
             );

--- a/src/components/ClientLayout.jsx
+++ b/src/components/ClientLayout.jsx
@@ -46,6 +46,12 @@ export default function ClientLayout({children, currentPageName}) {
         try {
             if (userData) {
                 const parsedUserData = JSON.parse(userData);
+                // Validate cookie has required fields — clear stale/corrupted cookies
+                if (!parsedUserData?.id || !parsedUserData?.role) {
+                    console.warn("Invalid cookie structure, clearing session");
+                    handleLogout();
+                    return;
+                }
                 setCurrentUser(parsedUserData);
             }
             // Set language preference from cookie or default to false
@@ -79,8 +85,8 @@ export default function ClientLayout({children, currentPageName}) {
                 {name: t.about, href: "/about"},
             ];
 
-            const isBarber = currentUser?.role.toUpperCase() === "BARBER";
-            const isAdmin = currentUser?.role.toUpperCase() === "ADMIN";
+            const isBarber = currentUser?.role?.toUpperCase() === "BARBER";
+            const isAdmin = currentUser?.role?.toUpperCase() === "ADMIN";
 
             if (isBarber || isAdmin) {
                 tempNavigation = [
@@ -141,7 +147,7 @@ export default function ClientLayout({children, currentPageName}) {
                 <AppBar position="fixed" sx={{bgcolor: '#2D5043', zIndex: 1200}}>
                     <Toolbar>
                         <Box sx={{flexGrow: 1, display: 'flex', alignItems: 'center'}}>
-                            <Link href={`/${currentUser?.role.toUpperCase() === "CUSTOMER" ? 'home' : 'management'}`}
+                            <Link href={`/${currentUser?.role?.toUpperCase() === "CUSTOMER" ? 'home' : 'management'}`}
                                   style={{display: 'flex', alignItems: 'center'}}>
                                 <Image
                                     src="/mrcut.png"


### PR DESCRIPTION
- Add optional chaining on role?.toUpperCase() in ClientLayout to prevent TypeError during render when cookie has missing/undefined role field
- Validate cookie structure on load and clear session if id or role fields are missing (handles pre-OTP legacy cookies)
- Add missing return on 401 in login route to prevent null reference crash when user not found in DB

Fixes production crash: Application error client-side exception affecting users with cookies from before OTP migration.